### PR TITLE
`system-type is a symbol, not a string, so `string=' will never evaluate 

### DIFF
--- a/modules/prelude-ui.el
+++ b/modules/prelude-ui.el
@@ -66,7 +66,7 @@ instead of Emacs's default theme."
  (tool-bar-mode -1)
  ;; the menu bar is mostly useless as well
  ;; but removing it under OS X doesn't make much sense
- (unless (string= system-type "darwin")
+ (unless (eq system-type 'darwin)
    (menu-bar-mode -1))
  ;; the blinking cursor is nothing, but an annoyance
  (blink-cursor-mode -1)


### PR DESCRIPTION
`system-type is a symbol, not a string, so`string=' will never evaluate to `t'
