### PR TITLE
Please add "eshell" to ".gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ auto-save-list
 recentf
 savehist
 saveplace
+eshell
 elpa
 el-get
 semanticdb


### PR DESCRIPTION
The eshell command will create an eshell/ subdir in emacs-prelude, which should be ignored by git.

Thanks!

(and thanks for emacs-prelude!)
