### PR TITLE
Fix ediff unnecessary frame

### DIFF
--- a/modules/prelude-editor.el
+++ b/modules/prelude-editor.el
@@ -175,6 +175,9 @@
 ;; dired - reuse current buffer by pressing 'a'
 (put 'dired-find-alternate-file 'disabled nil)
 
+;; ediff - don't start another frame
+(setq ediff-window-setup-function 'ediff-setup-windows-plain)
+
 (provide 'prelude-editor)
 
 ;;; prelude-editor.el ends here


### PR DESCRIPTION
It removes unnecessary frame used for control of ediff/emerge. With this fix it uses a window of one-line height. Makes ediff/emerge much more usable when used in tiling window manager.
