### PR TITLE
Cleanup tabs and whitespaces along with prelude-indent-region-or-buffer

### DIFF
--- a/modules/prelude-core.el
+++ b/modules/prelude-core.el
@@ -156,10 +156,14 @@ the curson at its beginning, according to the current mode."
   (save-excursion
     (if (region-active-p)
         (progn
+          (delete-trailing-whitespace (region-beginning) (region-end))
           (indent-region (region-beginning) (region-end))
+          (untabify (region-min) (region-max))
           (message "Indented selected region."))
       (progn
+        (delete-trailing-whitespace)
         (prelude-indent-buffer)
+        (untabify (point-min) (point-max))
         (message "Indented buffer.")))))
 
 (defun prelude-annotate-todo ()


### PR DESCRIPTION
Death to tabs and trailing whitespaces!! This is subjective improvement, but I believe if a user wants to auto-intend whole buffer or selected region, he is ready to cope with massive cosmetic changes in code (which lead to big diffs in VCS).
