### PR TITLE
Make C-c C-k aware of rebar and rebar.config

### DIFF
--- a/modules/prelude-erlang.el
+++ b/modules/prelude-erlang.el
@@ -47,6 +47,25 @@
     (add-to-list 'load-path wrangler-path)
     (require 'wrangler)))
 
+(defun erlang-rebar-compile ()
+  (interactive)
+  (let* ((dir (or (projectile-get-project-root)
+                  (file-name-directory (buffer-file-name))))
+         (pref (concat "cd " dir " && "))
+         (cmd (cond ((file-exists-p (expand-file-name "rebar" dir))    "./rebar compile")
+                    ((executable-find "rebar")                         "rebar compile")
+                    ((file-exists-p (expand-file-name "Makefile" dir)) "Makefile")
+                    (t nil))))
+    (if cmd
+        (compilation-start (concat pref cmd))
+      (call-interactively 'inferior-erlang-compile))
+    ))
+
+(add-hook 'erlang-mode-hook (lambda ()
+                              (make-variable-buffer-local 'projectile-project-root-files)
+                              (setq projectile-project-root-files '("rebar.config" ".git" ".hg" ".bzr" ".projectile"))
+                              (setq erlang-compile-function 'erlang-rebar-compile)))
+
 (provide 'prelude-erlang)
 
 ;;; prelude-erlang.el ends here


### PR DESCRIPTION
This commit makes Erlang C-c C-k aware of rebar, rebar.config and Makefile. When working on real-life projects internal erlang-mode compilation support is basically useless (although it is used as fallback if projectile is not able to find project root or when there is no usable rebar/rebar.config or when there is no Makefile).

Best,
Gleb
