### PR TITLE
google lookup doesn´t work with multiple words or special characters

### DIFF
--- a/modules/prelude-core.el
+++ b/modules/prelude-core.el
@@ -73,9 +73,9 @@ file of a buffer in an external program."
   (browse-url
    (concat
     "http://www.google.com/search?ie=utf-8&oe=utf-8&q="
-    (if mark-active
-        (buffer-substring (region-beginning) (region-end))
-      (read-string "Google: ")))))
+    (url-hexify-string (if mark-active
+                           (buffer-substring (region-beginning) (region-end))
+                         (read-string "Google: "))))))
 
 (defun prelude-indent-rigidly-and-copy-to-clipboard (begin end indent)
   "Copy the selected code region to the clipboard, indented according


### PR DESCRIPTION
I added `url-hexify-string` to escape those in the google query.
