### PR TITLE
Update to work with latest version of inf-ruby

### DIFF
--- a/modules/prelude-ruby.el
+++ b/modules/prelude-ruby.el
@@ -60,7 +60,7 @@
 (require 'ruby-end)
 
 (defun prelude-ruby-mode-defaults ()
-  (inf-ruby-keys)
+  (inf-ruby-setup-keybindings)
   ;; turn off the annoying input echo in irb
   (setq comint-process-echoes t)
   (ruby-block-mode t)


### PR DESCRIPTION
inf-ruby-keys renamed to inf-ruby-update-keybindings
