### PR TITLE
Load byte-compiled versions of personal libraries

### DIFF
--- a/init.el
+++ b/init.el
@@ -108,7 +108,8 @@ by Prelude.")
 
 ;; load the personal settings (this includes `custom-file')
 (when (file-exists-p prelude-personal-dir)
-  (mapc 'load (directory-files prelude-personal-dir nil "^[^#].*el$")))
+  (mapc 'load (mapcar (lambda (s) (substring s 0 -3))
+                      (directory-files prelude-personal-dir nil "^[^#].*el$"))))
 
 (message "Emacs Prelude is ready to do thy bidding, Master %s!"
          (getenv "USER"))


### PR DESCRIPTION
Prelude would previously ignore byte-compiled versions of personal libraries.  
