### PR TITLE
Fix bug where prelude-mode-map isn't found by prelude-programming

### DIFF
--- a/init.el
+++ b/init.el
@@ -55,10 +55,10 @@ ELPA (or MELPA).")
 (add-to-list 'load-path prelude-vendor-dir)
 
 ;; the core stuff
+(require 'prelude-mode)
 (require 'prelude-packages)
 (require 'prelude-ui)
 (require 'prelude-core)
-(require 'prelude-mode)
 (require 'prelude-editor)
 (require 'prelude-global-keybindings)
 


### PR DESCRIPTION
prelude-programming was getting loaded before prelude-mode, so prelude-programming wasn't finding prelude-mode-map for its keybindings.  This fixes the problem, but it might be better to fix it within the prelude-programming.
