### PR TITLE
Correct the display of Prelude minor mode in the modeline

### DIFF
--- a/prelude/prelude-mode.el
+++ b/prelude/prelude-mode.el
@@ -102,7 +102,7 @@
 
 (define-minor-mode prelude-mode
   "Minor mode to consolidate Emacs Prelude extensions."
-  :lighter "Prelude"
+  :lighter " Prelude"
   :keymap prelude-mode-map
   (if prelude-mode
       ;; on start


### PR DESCRIPTION
There isn't a space in front of the 'lighter' in the mode definition. That results in in butting up against the previous minor mode in in the modeline.
