### PR TITLE
Add path support for OSX

### DIFF
--- a/prelude/prelude-osx.el
+++ b/prelude/prelude-osx.el
@@ -1,7 +1,10 @@
 ;; On OS X Emacs doesn't use the shell PATH if it's not started from
-;; the shell. If you're using homebrew modifying the PATH is essential.
-(push "/usr/local/bin" exec-path)
-(setenv "PATH" (concat "/usr/local/bin:" (getenv "PATH")))
+;; the shell.
+;; If you're using homebrew or port, modifying the PATH is essential.
+(let (osx-paths)
+  (dolist (path '("/usr/local/bin" "/opt/local/bin" "/opt/local/sbin") (setenv "PATH" (concat osx-paths (getenv "PATH"))))
+    (push path exec-path)
+    (setq osx-paths (concat (concat path ":") osx-paths))))
 
 ;; Emacs users obviously have little need for Command and Option keys,
 ;; but they do need Meta and Super


### PR DESCRIPTION
macports binaries are located at /opt/local/bin and sbin

(This is my first emacs lisp commit. Let me know if you think this can be done in another way)
