### PR TITLE
Fixing Issue 163: invalid function with-selected-frame

### DIFF
--- a/prelude/prelude-ui.el
+++ b/prelude/prelude-ui.el
@@ -43,10 +43,9 @@
 (defun prelude-frame-config (frame)
   "Custom behaviours for new frames."
   (if (eq system-type 'darwin)
-      (with-selected-frame frame
-        (if (display-graphic-p)
-            (modify-frame-parameters frame '((menu-bar-lines . 1)))
-          (modify-frame-parameters frame '((menu-bar-lines . 0)))))
+      (if (display-graphic-p)
+          (modify-frame-parameters frame '((menu-bar-lines . 1)))
+        (modify-frame-parameters frame '((menu-bar-lines . 0))))
     (menu-bar-mode -1)))
 
 ;; run now


### PR DESCRIPTION
The function isn't loaded when Prelude tries to start up, resulting in
an error. I believe the intended effect can be achieved without its
use, and this change modifies the prelude-frame-config function in
accordance with this. I can now successfully load Prelude on my Mac.
