### PR TITLE
prelude-visit-term-buffer launches the user's $SHELL

### DIFF
--- a/prelude/prelude-core.el
+++ b/prelude/prelude-core.el
@@ -63,7 +63,7 @@ file of a buffer in an external program."
 (defun prelude-visit-term-buffer ()
   (interactive)
   (if (not (get-buffer "*ansi-term*"))
-      (ansi-term "/bin/bash")
+      (ansi-term (getenv "SHELL"))
     (switch-to-buffer "*ansi-term*")))
 
 (defun prelude-google ()


### PR DESCRIPTION
In `prelude-visit-term-buffer` I changed `(ansi-term "/bin/bash")` to  `(ansi-term (getenv "SHELL"))`.

That's all.
