### PR TITLE
Fixed loading of incorrect package for rainbow-delimiters

### DIFF
--- a/prelude/prelude-packages.el
+++ b/prelude/prelude-packages.el
@@ -43,7 +43,7 @@
 
 (defvar prelude-packages
   '(ack-and-a-half expand-region gist guru-mode helm helm-projectile magit magithub melpa
-                   rainbow-mode volatile-highlights yasnippet zenburn-theme)
+                   rainbow-delimiters volatile-highlights yasnippet zenburn-theme)
   "A list of packages to ensure are installed at launch.")
 
 (defun prelude-packages-installed-p ()


### PR DESCRIPTION
New prelude user as of today, following the install instructions and kept getting a bunch of errors. Boy, this took a bit to track down. Learned a fair amount about prelude in the process, though, so that's good I suppose.

Looks like the rainbow-mode package in MELPA got renamed to rainbow-delimiters sometime recently. I see in the commit history for the zenburn theme that the eval got updated to reflect the name change, but it looks like the package autoload list for prelude did not. This commit fixes that, and clears up the errors I was seeing on install.

Cheers!
