### PR TITLE
Use forward-line instead of next-/previous-line.

### DIFF
--- a/prelude/prelude-core.el
+++ b/prelude/prelude-core.el
@@ -103,21 +103,21 @@ the curson at its beginning, according to the current mode."
   (interactive)
   (move-end-of-line nil)
   (open-line 1)
-  (next-line 1)
+  (forward-line 1)
   (indent-according-to-mode))
 
 (defun prelude-move-line-up ()
   "Move up the current line."
   (interactive)
   (transpose-lines 1)
-  (previous-line 2))
+  (forward-line -2))
 
 (defun prelude-move-line-down ()
   "Move down the current line."
   (interactive)
-  (next-line 1)
+  (forward-line 1)
   (transpose-lines 1)
-  (previous-line 1))
+  (forward-line -1))
 
 ;; add the ability to copy and cut the current line, without marking it
 (defadvice kill-ring-save (before slick-copy activate compile)


### PR DESCRIPTION
To move by line, use:

``` lisp
(forward-line 1)
(forward-line -1)
```

These are written in C. They put the cursor to the beginning of previous/next line.

Do not use `next-line` or `previous-line`. Because these are for interactive use. Their behavior changes depending on the variable `line-move-visual`.

More information [here](http://ergoemacs.org/emacs/elisp_all_about_lines.html)
