### PR TITLE
Fix obsolete warnings (as of yasnippet 0.8):

### DIFF
--- a/prelude/prelude-editor.el
+++ b/prelude/prelude-editor.el
@@ -188,8 +188,8 @@
 
 ;; load yasnippet
 (require 'yasnippet)
-(add-to-list 'yas/snippet-dirs prelude-snippets-dir)
-(yas/global-mode 1)
+(add-to-list 'yas-snippet-dirs prelude-snippets-dir)
+(yas-global-mode 1)
 
 ;; projectile is a project management mode
 (require 'projectile)


### PR DESCRIPTION
- use `yas-snippet-dirs` instead of obsolete `yas/snippet-dirs`
- use `yas-global-mode` instead of obsolete `yas/global-mode`
