### PR TITLE
fixed helm-mini fallback if no projectile is available

### DIFF
--- a/prelude/prelude-editor.el
+++ b/prelude/prelude-editor.el
@@ -219,16 +219,19 @@
 (defun helm-prelude ()
   "Preconfigured `helm'."
   (interactive)
-  (if (projectile-project-root)
-      ;; add project files and buffers when in project
-      (helm-other-buffer '(helm-c-source-projectile-files-list
-                           helm-c-source-projectile-buffers-list
-                           helm-c-source-buffers-list
-                           helm-c-source-recentf
-                           helm-c-source-buffer-not-found)
-                         "*helm prelude*")
-    ;; otherwise fallback to helm-mini
-    (helm-mini)))
+  (condition-case nil
+    (if (projectile-project-root)
+        ;; add project files and buffers when in project
+        (helm-other-buffer '(helm-c-source-projectile-files-list
+                             helm-c-source-projectile-buffers-list
+                             helm-c-source-buffers-list
+                             helm-c-source-recentf
+                             helm-c-source-buffer-not-found)
+                           "*helm prelude*")
+      ;; otherwise fallback to helm-mini
+      (helm-mini))
+    ;; fall back to helm mini if an error occurs (usually in projectile-project-root)
+    (error (helm-mini))))
 
 ;; shorter aliases for ack-and-a-half commands
 (defalias 'ack 'ack-and-a-half)


### PR DESCRIPTION
Hi,
I had a minor problem with the helm integration (C-c h) when not in a projectile project.

Description:
The projectile-project-root function may signal an error, which is not handled in the helm-prelude function. This can cause the function to abort with the "You're not into a project" error instead of falling back to helm-mini.

Warning: I'm not a lisp programmer, so I'm sure there's a better way to do it. For me it works, and it doesn't seem to break anything.

Greets,
Chris
