### PR TITLE
Make `package-user-dir` relative to Prelude

### DIFF
--- a/prelude/prelude-packages.el
+++ b/prelude/prelude-packages.el
@@ -36,6 +36,8 @@
 (require 'package)
 (add-to-list 'package-archives
              '("melpa" . "http://melpa.milkbox.net/packages/") t)
+;; set package-user-dir to be relative to Prelude install path
+(setq package-user-dir (expand-file-name "elpa" prelude-dir))
 (package-initialize)
 
 ;; required because of a package.el bug


### PR DESCRIPTION
The default value of `package-user-dir` is `~/.emacs.d/elpa`, which means that if Prelude is being run from a different directory (e.g `emacs -q -l ~/src/prelude/init.el`), the packages will get put into the user's `~/.emacs.d` whether they like it or not.

This makes the entire Prelude configuration fully portable by making the `package-user-dir` relative to the install path of `prelude-dir`, meaning it's easier to try out in different Emacs enviroments.
