### PR TITLE
Update prelude/prelude-osx.el

### DIFF
--- a/prelude/prelude-osx.el
+++ b/prelude/prelude-osx.el
@@ -1,5 +1,6 @@
 ;; On OS X Emacs doesn't use the shell PATH if it's not started from
 ;; the shell. Let's fix that:
+(require 'exec-path-from-shell)
 (exec-path-from-shell-initialize)
 
 ;; Emacs users obviously have little need for Command and Option keys,


### PR DESCRIPTION
This fixes an error I got: "Symbol's function definition is void: exec-path-from-shell-initialize"
