### PR TITLE
Fix dash.el opening warning

### DIFF
--- a/init.el
+++ b/init.el
@@ -58,9 +58,6 @@ ELPA (or MELPA).")
 (unless (file-exists-p prelude-savefile-dir)
   (make-directory prelude-savefile-dir))
 
-(require 'cl)
-(require 'dash)
-
 (defun prelude-add-subfolders-to-load-path (parent-dir)
  "Adds all first level `parent-dir' subdirs to the
 Emacs load path."
@@ -76,6 +73,9 @@ Emacs load path."
 (add-to-list 'load-path prelude-modules-dir)
 (add-to-list 'load-path prelude-vendor-dir)
 (prelude-add-subfolders-to-load-path prelude-vendor-dir)
+
+(require 'cl)
+(require 'dash)
 
 ;; the core stuff
 (require 'prelude-packages)


### PR DESCRIPTION
Prelude won't start due to "Cannot open load file: dash.el" issue after commit 56d2ec3.

This moves down dash module loading below the adding vendor dir (dash.el location) to the 'load-path' list.
