### PR TITLE
Use the more up-to-date scala-mode2 for Scala

### DIFF
--- a/modules/prelude-scala.el
+++ b/modules/prelude-scala.el
@@ -34,12 +34,11 @@
 ;;; Code:
 
 (require 'prelude-programming)
-(prelude-ensure-module-deps '(scala-mode))
+(prelude-ensure-module-deps '(scala-mode2))
 
-(require 'scala-mode-auto)
+(require 'scala-mode2)
 
 (defun prelude-scala-mode-defaults ()
-  (run-hooks 'prelude-prog-mode-hook) ;; run manually; not derived from prog-mode
   (subword-mode +1))
 
 (setq prelude-scala-mode-hook 'prelude-scala-mode-defaults)


### PR DESCRIPTION
The old `scala-mode` is quite bloated and contains a lot of features that are better provided by other packages. A new mode has recently been written, which adheres to both modern Scala as well as Elisp standards (for example by deriving from `prog-mode`, and highlighting all Scala <= 2.9 syntactical features).
