### PR TITLE
Require undo-tree before setting it globally

### DIFF
--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -345,6 +345,7 @@ indent yanked text (with prefix arg don't indent)."
 (prelude-global-mode t)
 
 ;; sensible undo
+(require 'undo-tree)
 (global-undo-tree-mode)
 
 ;; enable winner-mode to manage window configurations


### PR DESCRIPTION
I wast getting an error when starting Emacs:

> Symbol's function definition is void: global-undo-tree-mode

Adding the require before setting this mode makes it start cleanly.
