### PR TITLE
Make cleaning white space on save an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,19 @@ personal config with the following bit of code:
 (setq prelude-whitespace nil)
 ```
 
+If you like `whitespace-mode` but prefer it to not automatically
+cleanup your file on save, you can disable that behavior by setting
+prelude-clean-whitespace-on-save to nil in your config file with:
+
+```lisp
+(setq prelude-clean-whitespace-on-save nil)
+```
+
+The prelude-clean-whitespace-on-save setting can also be set on a
+per-file or directory basis by using a file variable or a
+.dir-locals.el file.
+
+
 #### Disable flyspell-mode
 
 If you're not fond of spellchecking on the fly:

--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -225,7 +225,7 @@
     (flyspell-mode +1)))
 
 (defun prelude-cleanup-maybe ()
-    (when prelude-clean-whitespace-on-save (whitespace-cleanup)))
+  (when prelude-clean-whitespace-on-save (whitespace-cleanup)))
 
 (defun prelude-enable-whitespace ()
   (when prelude-whitespace


### PR DESCRIPTION
I really like using white-space mode. 

However I'm often working on an existing third-party code base and I don't like turning in a huge commit with only one line of _real_ changes and the rest is whitespace cleanups.

Accordingly, what I really need is to visually see all the white-space,
but it not be cleaned up when the file is saved.  But only for the one project, I still want to auto-fix my own code.

To accomplish this I've added a prelude-clean-whitespace-on-save config.  The config's value is checked on save so it can be over-ridden by dir-locals. If someone has a better (briefer) name or other suggestions, I'll be happy to rework.

Thanks much for all the great work!
