### PR TITLE
Correct link, spelling, and markup in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ extensions to keybindings.
 Keybinding         | Description
 -------------------|------------------------------------------------------------
 <kbd>C-M-h</kbd>   | Kill the previous word(`backward-kill-word`). (as in Bash/Zsh)
-<kbd>C-x \</kbd>   | `align-regexp`
+<kbd>C-x \\</kbd>   | `align-regexp`
 <kbd>C-+</kbd>     | Increase font size(`text-scale-increase`).
 <kbd>C--</kbd>     | Decrease font size(`text-scale-decrease`).
 <kbd>C-x O</kbd>   | Go back to previous window (the inverse of `other-window` (`C-x o`)).
@@ -197,7 +197,7 @@ Keybinding         | Description
 <kbd>C-x M-m</kbd> | Start your default shell.
 <kbd>C-x C-m</kbd> | Alias for `M-x`.
 <kbd>C-h A</kbd>   | Run `apropos` (search in all Emacs symbols).
-<kbd>M-\</kbd>     | Run `hippie-expand` (a replacement for the default `dabbrev-expand`).
+<kbd>M-\\</kbd>     | Run `hippie-expand` (a replacement for the default `dabbrev-expand`).
 <kbd>C-x C-b</kbd> | Open `ibuffer` (a replacement for the default `buffer-list`).
 <kbd>F12</kbd>     | Toggle the Emacs menu bar.
 <kbd>C-x g</kbd>   | Open Magit's status buffer.
@@ -213,8 +213,8 @@ Keybinding         | Description
 <kbd>C-S-up</kbd>  | Move the current line up.
 <kbd>C-S-down</kbd> | Move the current line down.
 <kbd>C-c n</kbd> | Fix indentation in buffer and strip whitespace.
-<kbd>C-c f</kbd> | Open recently visitted file.
-<kbd>C-M-\</kbd> | Indent region (if selected) or the entire buffer.
+<kbd>C-c f</kbd> | Open recently visited file.
+<kbd>C-M-\\</kbd> | Indent region (if selected) or the entire buffer.
 <kbd>C-c u</kbd> | Open URL in your default browser.
 <kbd>C-c e</kbd> | Eval a bit of Emacs Lisp code and replace it with its result.
 <kbd>C-c s</kbd> | Swap two active windows.
@@ -226,7 +226,7 @@ Keybinding         | Description
 
 #### Projectile
 
-Here's a list of functionality provided by [Projectile](https://github.com/bbatsov/prelude):
+Here's a list of functionality provided by [Projectile](https://github.com/bbatsov/projectile):
 
 Keybinding         | Description
 -------------------|------------------------------------------------------------


### PR DESCRIPTION
Just some minor corrections to the Readme file.
