### PR TITLE
Don't try edit dired buffer as root

### DIFF
--- a/core/prelude-core.el
+++ b/core/prelude-core.el
@@ -265,8 +265,8 @@ buffer is not visiting a file."
 (defadvice ido-find-file (after find-file-sudo activate)
   "Find file as root if necessary."
   (unless (or (equal major-mode 'dired-mode)
-               (and (buffer-file-name)
-                (file-writable-p buffer-file-name)))
+              (and (buffer-file-name)
+                   (file-writable-p buffer-file-name)))
     (find-alternate-file (concat "/sudo:root@localhost:" buffer-file-name))))
 
 (defun prelude-switch-or-start (function buffer)


### PR DESCRIPTION
With the advised ido-find-file, invoking dired using C-d attempts to open dired buffer as root.
