### PR TITLE
Recenter the screen after goto-symbol

### DIFF
--- a/modules/prelude-programming.el
+++ b/modules/prelude-programming.el
@@ -63,7 +63,8 @@
        ((overlayp position)
         (goto-char (overlay-start position)))
        (t
-        (goto-char position)))))
+        (goto-char position)))
+      (recenter)))
    ((listp symbol-list)
     (dolist (symbol symbol-list)
       (let (name position)


### PR DESCRIPTION
When I go to a symbol, the symbol is always at the bottom of the screen. I have to move the cusor down to see the body of the symbol, so I think it's better to recenter the screen after goto-symbol.
