### PR TITLE
Add autoloads of major modes for PKGBUILD and .zshrc file

### DIFF
--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -381,6 +381,9 @@ indent yanked text (with prefix arg don't indent)."
 (add-hook 'after-save-hook
           'executable-make-buffer-file-executable-if-script-p)
 
+;; .zsh file is shell script too
+(add-to-list 'auto-mode-alist '("\\.zsh\\'" . shell-script-mode))
+
 ;; whitespace-mode config
 (require 'whitespace)
 (setq whitespace-line-column 80) ;; limit line length

--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -96,6 +96,7 @@ PACKAGE is installed only if not already present.  The file is opened in MODE."
     ("\\.md\\'" markdown-mode markdown-mode)
     ("\\.ml\\'" tuareg tuareg-mode)
     ("\\.php\\'" php-mode php-mode)
+    ("PKGBUILD\\'" pkgbuild-mode pkgbuild-mode)
     ("\\.sass\\'" sass-mode sass-mode)
     ("\\.scala\\'" scala-mode2 scala-mode)
     ("\\.scss\\'" scss-mode scss-mode)
@@ -108,6 +109,9 @@ PACKAGE is installed only if not already present.  The file is opened in MODE."
 (when (package-installed-p 'markdown-mode)
   (add-to-list 'auto-mode-alist '("\\.markdown\\'" . markdown-mode))
   (add-to-list 'auto-mode-alist '("\\.md\\'" . markdown-mode)))
+
+(when (package-installed-p 'pkgbuild-mode)
+  (add-to-list 'auto-mode-alist '("PKGBUILD\\'" . pkgbuild-mode)))
 
 ;; build auto-install mappings
 (mapc


### PR DESCRIPTION
Note: A PKGBUILD is an Arch Linux package build description file (actually it is a shell script) used when creating packages.
