### PR TITLE
Removed the key-chord 'kk' because it conflicts with common words in the Danish language.

### DIFF
--- a/core/prelude-global-keybindings.el
+++ b/core/prelude-global-keybindings.el
@@ -117,7 +117,6 @@
 (key-chord-define-global "jj" 'ace-jump-word-mode)
 (key-chord-define-global "jl" 'ace-jump-line-mode)
 (key-chord-define-global "jk" 'ace-jump-char-mode)
-(key-chord-define-global "kk" 'just-one-space)
 (key-chord-define-global "KK" 'delete-horizontal-space)
 (key-chord-define-global "JJ" 'prelude-switch-to-previous-buffer)
 (key-chord-define-global "uu" 'undo-tree-visualize)


### PR DESCRIPTION
Danish words, such as 'ikke' (en: not), 'drikke' (en: to drink), and tons of danish names has two Ks after each other, such as "Frederikke", "Rikke", "Mikkel", etc.

The 'kk' key-chord makes text buffers, such as ERC nearly unusable. I have no good suggestion of what to replace it with; but I would really like to have it moved to another combination.
