### PR TITLE
Fix lisp code blocks in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,15 +276,15 @@ in which case you can disable the binding in your `personal.el` file by setting
 its command to `nil`. For example, to disable the `kk` key-chord add the
 following line:
 
-    ```lisp
-    (key-chord-define-global "jj" nil)
-    ```
+```lisp
+(key-chord-define-global "jj" nil)
+```
 
 If you're an `evil-mode` user you'll probably do well to disable `key-chord-mode` altogether:
 
-    ```lisp
-    (key-chord-mode -1)
-    ```
+```lisp
+(key-chord-mode -1)
+```
 
 ## Automatic package installation
 


### PR DESCRIPTION
Just noticed a couple Lisp blocks in the README were improperly formatted.
