### PR TITLE
Remove paredit stuff from prelude-common-lisp.el

### DIFF
--- a/modules/prelude-common-lisp.el
+++ b/modules/prelude-common-lisp.el
@@ -72,11 +72,11 @@
 
 ;; Stop SLIME's REPL from grabbing DEL,
 ;; which is annoying when backspacing over a '('
-(defun prelude-override-slime-repl-bindings-with-paredit ()
-  (define-key slime-repl-mode-map
-    (read-kbd-macro paredit-backward-delete-key) nil))
+;; (defun prelude-override-slime-repl-bindings-with-paredit ()
+;;   (define-key slime-repl-mode-map
+;;     (read-kbd-macro paredit-backward-delete-key) nil))
 
-(add-hook 'slime-repl-mode-hook 'prelude-override-slime-repl-bindings-with-paredit)
+;; (add-hook 'slime-repl-mode-hook 'prelude-override-slime-repl-bindings-with-paredit)
 
 (eval-after-load "slime"
   '(progn


### PR DESCRIPTION
The paredit backspace override without having paredit-backward-delete-key defined by paredit was breaking slime loading. I commented this out rather than deleting it since I noticed you had just commented out other paredit stuff elsewhere
