### PR TITLE
Adds linum-mode to prelude-prog-mode-defaults.

### DIFF
--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -64,6 +64,11 @@ Will only occur if prelude-whitespace is also enabled."
   :type 'boolean
   :group 'prelude)
 
+(defcustom prelude-linum t
+  "Non-nil values enable display of line numbers."
+  :type 'boolean
+  :group 'prelude)
+
 ;; Death to the tabs!  However, tabs historically indent to the next
 ;; 8-character offset; specifying anything else will cause *mass*
 ;; confusion, as it will change the appearance of every existing file.
@@ -252,6 +257,11 @@ Will only occur if prelude-whitespace is also enabled."
     ;; keep the whitespace decent all the time (in this buffer)
     (add-hook 'before-save-hook 'prelude-cleanup-maybe nil t)
     (whitespace-mode +1)))
+
+(defun prelude-enable-linum ()
+  "Enable `linum-mode' if `prelude-linum' is not nil."
+  (when prelude-linum
+    (linum-mode +1)))
 
 (add-hook 'text-mode-hook 'prelude-enable-flyspell)
 (add-hook 'text-mode-hook 'prelude-enable-whitespace)

--- a/modules/prelude-programming.el
+++ b/modules/prelude-programming.el
@@ -118,6 +118,7 @@
   (when prelude-guru
     (guru-mode +1))
   (prelude-enable-whitespace)
+  (prelude-enable-linum)
   (prelude-local-comment-auto-fill)
   (prelude-add-watchwords))
 


### PR DESCRIPTION
I think it's very helpful to have line numbers by default when working with code. Most text editors feature it and people expect them to be there. I know that many people use Emacs for much more than text editing it so I added this feature only to prelude coding hook. If this feature goes against the Prelude vision I understand and it's ok. This is just a simple change. 
