### PR TITLE
flx-ido does not exist but flx does

### DIFF
--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -42,7 +42,7 @@
 
 (defvar prelude-packages
   '(ace-jump-mode ack-and-a-half dash diminish elisp-slime-nav
-    expand-region flx-ido flycheck gist
+    expand-region flx flycheck gist
     git-commit-mode gitconfig-mode gitignore-mode grizzl
     guru-mode helm helm-projectile ido-ubiquitous
     key-chord magit rainbow-mode


### PR DESCRIPTION
I had to change flx-ido to flx to avoid the following:

error: Package `flx-ido' is not available for installation
