### PR TITLE
Add command to make Emacs window fullscreen

### DIFF
--- a/core/prelude-core.el
+++ b/core/prelude-core.el
@@ -514,13 +514,17 @@ With numeric prefix arg DEC, decrement the integer by DEC amount."
   (interactive "p")
   (prelude-increment-integer-at-point (- (or dec 1))))
 
-(defun prelude-fullscreen ()
-  "Makes Emacs window fullscreen.
+;;; Emacs in OSX already has fullscreen support
+(when (eq window-system 'x)
+  (defun prelude-fullscreen ()
+    "Makes Emacs window fullscreen.
 
-This follows freedesktop standards."
-  (interactive)
-  (x-send-client-message nil 0 nil "_NET_WM_STATE" 32
-                         '(2 "_NET_WM_STATE_FULLSCREEN" 0)))
+This follows freedesktop standards, should work in X servers."
+    (interactive)
+    (x-send-client-message nil 0 nil "_NET_WM_STATE" 32
+                           '(2 "_NET_WM_STATE_FULLSCREEN" 0)))
+  (global-set-key (kbd "<f11>") 'prelude-fullscreen)
+)
 
 (provide 'prelude-core)
 ;;; prelude-core.el ends here

--- a/core/prelude-global-keybindings.el
+++ b/core/prelude-global-keybindings.el
@@ -96,9 +96,6 @@
 ;; replace buffer-menu with ibuffer
 (global-set-key (kbd "C-x C-b") 'ibuffer)
 
-;; make window fullscreen
-(global-set-key (kbd "<f11>") 'prelude-fullscreen)
-
 ;; toggle menu-bar visibility
 (global-set-key (kbd "<f12>") 'menu-bar-mode)
 


### PR DESCRIPTION
Default keybinding is F11. The command follows freedesktop standards, so it should work on most desktops, at least in GNU/Linux systems.

I tested it on KDE. If it doesn't work on OSX we could introduce a new file _prelude_linux.el_ and put it there, analogously as _prelude_osx.el_ is being loaded now.
