### PR TITLE
Username fix for windows-nt

### DIFF
--- a/init.el
+++ b/init.el
@@ -33,7 +33,9 @@
 
 ;;; Code:
 
-(message "Prelude is powering up... Be patient, Master %s!" (getenv "USER"))
+(message "Prelude is powering up... Be patient, Master %s!"
+         (getenv
+          (if (equal system-type 'windows-nt) "USERNAME" "USER")))
 
 (defvar prelude-dir (file-name-directory load-file-name)
   "The root dir of the Emacs Prelude distribution.")


### PR DESCRIPTION
I use emacs on windows 7 and initial startup message reads as "Prelude is powering up... Be patient, Master nil", I have added a if condition to use env variable USERNAME if its a windows-nt system, else use USER.
