### PR TITLE
Unbind conflicting prelude-mode keys.

### DIFF
--- a/modules/prelude-org.el
+++ b/modules/prelude-org.el
@@ -38,12 +38,19 @@
 (global-set-key "\C-cb" 'org-iswitchb)
 (setq org-log-done t)
 
-;; (defun prelude-org-mode-defaults ()
-;; )
+(defun prelude-org-mode-defaults ()
+  (let ((oldmap (cdr (assoc 'prelude-mode minor-mode-map-alist)))
+        (newmap (make-sparse-keymap)))
+    (set-keymap-parent newmap oldmap)
+    (define-key newmap (kbd "C-c +") nil)
+    (define-key newmap (kbd "C-c -") nil)
+    (make-local-variable 'minor-mode-overriding-map-alist)
+    (push `(prelude-mode . ,newmap) minor-mode-overriding-map-alist))
+)
 
-;; (setq prelude-org-mode-hook 'prelude-org-mode-defaults)
+(setq prelude-org-mode-hook 'prelude-org-mode-defaults)
 
-;; (add-hook 'org-mode-hook (lambda () (run-hooks 'prelude-org-mode-hook)))
+(add-hook 'org-mode-hook (lambda () (run-hooks 'prelude-org-mode-hook)))
 
 (provide 'prelude-org)
 


### PR DESCRIPTION
Solves https://github.com/bbatsov/prelude/issues/394. I took the code from this [Stack Overflow answer](http://stackoverflow.com/questions/13102494/buffer-locally-overriding-minor-mode-key-bindings-in-emacs). The difference between this solution and the one you had suggested is that this disables the prelude-mode bindings in question only for org-mode buffers, rather than globally. 
