### PR TITLE
Fix bug in prelude-kill-whole-line with prefix argument

### DIFF
--- a/core/prelude-core.el
+++ b/core/prelude-core.el
@@ -126,7 +126,7 @@ With a prefix ARG open line above the current line."
 (defun prelude-kill-whole-line (&optional arg)
   "A simple wrapper around command `kill-whole-line' that respects indentation.
 Passes ARG to command `kill-whole-line' when provided."
-  (interactive "P")
+  (interactive "p")
   (kill-whole-line arg)
   (back-to-indentation))
 


### PR DESCRIPTION
`prelude-kill-whole-line` would error out with `prelude-kill-whole-line: Wrong type argument: number-or-marker-p, (4)` when passing it a <kbd>c-u</kbd> argument (i.e. <kbd>c-u</kbd> <kbd>s-k</kbd>).

The fix is to use `(interactive "p")` in the wrapper function `prelude-kill-whole-line`, just as `kill-whole-line` does in `simple.el`.

From `interactive` help page:

```
p -- Prefix arg converted to number.  Does not do I/O.
P -- Prefix arg in raw form.  Does not do I/O.
```

The problem is that the `(interactive "p")` doesn't do any processing on the argument within `kill-whole-line` because only the wrapper method is called interactively, so unfortunately we can't just pass in a raw argument.
