### PR TITLE
Don't need to require the `smartparens-ruby` explicitly.

### DIFF
--- a/modules/prelude-ruby.el
+++ b/modules/prelude-ruby.el
@@ -33,7 +33,6 @@
 ;;; Code:
 
 (require 'prelude-programming)
-(require 'smartparens-ruby)
 
 (prelude-ensure-module-deps '(ruby-tools inf-ruby yari))
 


### PR DESCRIPTION
As of the smartparens-config will require automatically. Here is the [code](https://github.com/Fuco1/smartparens/blob/master/smartparens-config.el#L74).
