### PR TITLE
Use correct hook for el-doc

### DIFF
--- a/modules/prelude-clojure.el
+++ b/modules/prelude-clojure.el
@@ -49,7 +49,7 @@
 
 (eval-after-load 'cider
   '(progn
-     (add-hook 'cider-interaction-mode-hook 'cider-turn-on-eldoc-mode)
+     (add-hook 'cider-mode-hook 'cider-turn-on-eldoc-mode)
 
      (defun prelude-cider-mode-defaults ()
        (subword-mode +1)


### PR DESCRIPTION
According to the cider docs, the hook for adding el-doc to clojure buffers is cider-mode-hook.
