### PR TITLE
Fix README key binding for prelude-smart-open-line-above.

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Keybinding         | Description
 <kbd>C-c G</kbd>   | Search in GitHub for the thing under point (or an interactive query).
 <kbd>C-c y</kbd>   | Search in YouTube for the thing under point (or an interactive query).
 <kbd>C-S-RET</kbd> or <kbd>M-o</kbd> | Insert an empty line above the current line and indent it properly
-<kbd>S-RET</kbd> or <kbd>Super-O</kbd> | Insert an empty line and indent it properly (as in most IDEs).
+<kbd>S-RET</kbd> or <kbd>M-O</kbd> or <kbd>Super-o</kbd> | Insert an empty line and indent it properly (as in most IDEs).
 <kbd>C-S-up</kbd> or <kbd>M-S-up</kbd> | Move the current line or region up.
 <kbd>C-S-down</kbd> or <kbd>M-S-down</kbd>| Move the current line or region down.
 <kbd>C-c n</kbd> | Fix indentation in buffer and strip whitespace.


### PR DESCRIPTION
I'm not sure whether the code or the documentation in the README expresses the preferred key binding. I corrected the README to match the code.
