### PR TITLE
customise package-user-directory

### DIFF
--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -35,27 +35,8 @@
 (require 'cl)
 (require 'package)
 
-(defgroup prelude-package nil
-  "Emacs Prelude Package configuration."
-  :prefix "prelude-"
-  :group 'prelude)
-
-(defcustom prelude-use-package-user-directory nil
-  "Non-nil values set package-user-dir to be relative to Prelude install path."
-  :type 'boolean
-  :group 'prelude-package)
-
-(defcustom prelude-package-user-directory (expand-file-name "elpa" prelude-dir)
-  "Variable for package-user-dir to be relative to Prelude install path."
-  :type 'directory
-  :group 'prelude-package)
-
 (add-to-list 'package-archives
              '("melpa" . "http://melpa.milkbox.net/packages/") t)
-
-(when prelude-use-package-user-directory
-  ;; set package-user-dir to be relative to Prelude install path
-  (setq package-user-dir prelude-package-user-directory))
 (package-initialize)
 
 (defvar prelude-packages

--- a/init.el
+++ b/init.el
@@ -83,10 +83,6 @@ by Prelude.")
 ;; each 50MB of allocated data (the default is on every 0.76MB)
 (setq gc-cons-threshold 50000000)
 
-;; config changes made through the customize UI will be store here
-(setq custom-file (expand-file-name "custom.el" prelude-personal-dir))
-(if (file-exists-p custom-file) (load custom-file))
-
 ;; the core stuff
 (require 'prelude-packages)
 (require 'prelude-ui)
@@ -103,7 +99,10 @@ by Prelude.")
 (when (file-exists-p prelude-modules-file)
   (load prelude-modules-file))
 
-;; load the personal settings
+;; config changes made through the customize UI will be store here
+(setq custom-file (expand-file-name "custom.el" prelude-personal-dir))
+
+;; load the personal settings (this includes `custom-file')
 (when (file-exists-p prelude-personal-dir)
   (message "Loading personal configuration files in %s..." prelude-personal-dir)
   (mapc 'load (directory-files prelude-personal-dir 't "^[^#].*el$")))


### PR DESCRIPTION
https://github.com/bbatsov/prelude/pull/232

above pull makes that user can't customise package-user-directory. 

so, before loading prelude-pacakge, load custom-file and  

if `prelude-use-package-user-directory' is non-nil, set package-user-dir to be relative to Prelude install path.
