### PR TITLE
Fix key-chord module commentary.

### DIFF
--- a/modules/prelude-key-chord.el
+++ b/modules/prelude-key-chord.el
@@ -1,4 +1,4 @@
-;;; prelude-key-chord.el --- Helm setup
+;;; prelude-key-chord.el --- Key chord setup
 ;;
 ;; Copyright © 2011-2013 Bozhidar Batsov
 ;;
@@ -11,7 +11,7 @@
 
 ;;; Commentary:
 
-;; Some config for Helm.
+;; Configure key-chord key bindings.
 
 ;;; License:
 


### PR DESCRIPTION
This was clearly copied from the Helm module but the header and commentary weren't changed. I noticed it when wondering why my key-chord stopped working :)
