### PR TITLE
core/prelude-packages.el: Add helm-projectile and key-chord

### DIFF
--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -45,7 +45,7 @@
   '(ace-jump-mode ack-and-a-half anzu dash diminish elisp-slime-nav
     epl expand-region flx-ido flycheck gist
     gitconfig-mode gitignore-mode grizzl
-    guru-mode projectile ido-ubiquitous
+    guru-mode helm-projectile key-chord projectile ido-ubiquitous
     magit move-text rainbow-mode
     smartparens smex undo-tree
     volatile-highlights zenburn-theme)


### PR DESCRIPTION
When using option "(byte-recompile-directory user-emacs-directory 0)",
it throws the following error messages when starting Emacs with prelude
for the first time:

prelude-helm.el:37:1:Error: Cannot open load file: helm-misc
prelude-key-chord.el:37:1:Error: Cannot open load file: key-chord
