### PR TITLE
`lisp-complete-symbol` is obsolete

### DIFF
--- a/modules/prelude-lisp.el
+++ b/modules/prelude-lisp.el
@@ -36,7 +36,7 @@
 (prelude-require-packages '(rainbow-delimiters))
 
 ;; Lisp configuration
-(define-key read-expression-map (kbd "TAB") 'lisp-complete-symbol)
+(define-key read-expression-map (kbd "TAB") 'completion-at-point)
 
 ;; wrap keybindings
 (define-key lisp-mode-shared-map (kbd "M-(") (prelude-wrap-with "("))


### PR DESCRIPTION
Use `completion-at-point` since `lisp-complete-symbol` is obsolete as of Emacs 24.4.
