### PR TITLE
Use ruby-mode for Podfile

### DIFF
--- a/modules/prelude-ruby.el
+++ b/modules/prelude-ruby.el
@@ -48,6 +48,7 @@
 (add-to-list 'auto-mode-alist '("Thorfile\\'" . ruby-mode))
 (add-to-list 'auto-mode-alist '("Vagrantfile\\'" . ruby-mode))
 (add-to-list 'auto-mode-alist '("\\.jbuilder\\'" . ruby-mode))
+(add-to-list 'auto-mode-alist '("Podfile\\'" . ruby-mode))
 
 ;; We never want to edit Rubinius bytecode
 (add-to-list 'completion-ignored-extensions ".rbc")


### PR DESCRIPTION
A Podfile is used for CocoaPods to do a Bundler like dependency
management in XCode projects. Similar to a Rakefile or a Gemfile the
Podfile contains a dependency description in a Ruby based DSL.
