### PR TITLE
ignore personal and vendor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ session*
 .cask
 tramp
 /var/pcache
+personal/*
+!personal/.gitkeep
+vendor/*
+!vendor/.gitkeep


### PR DESCRIPTION
This ignore strategy allows the personal and vendor folders to exist in
the project, while also ignoring any files one might add to them thus
keeping the environment clean when looking to contribute to the project
