### PR TITLE
don't enable coffee-cos mode if buffer filename is nil

### DIFF
--- a/modules/prelude-coffee.el
+++ b/modules/prelude-coffee.el
@@ -58,8 +58,9 @@
        (setq coffee-command "~/dev/coffee")
 
        ;; Compile '.coffee' files on every save
-       (and (file-exists-p (buffer-file-name))
-            (file-exists-p (coffee-compiled-file-name))
+       (and (buffer-file-name)
+            (file-exists-p (buffer-file-name))
+            (file-exists-p (coffee-compiled-file-name (buffer-file-name)))
             (coffee-cos-mode t)))
 
      (setq prelude-coffee-mode-hook 'prelude-coffee-mode-defaults)


### PR DESCRIPTION
Hi!
This PR fixes `magit-ediff` fail (by pressing `e` on a `.coffee`-file in `magit-status`):
 `buffer-file-name` returns `nil` and `file-exists-p` fails.
