### PR TITLE
Open files with .cl extension in lisp-mode

### DIFF
--- a/modules/prelude-common-lisp.el
+++ b/modules/prelude-common-lisp.el
@@ -38,7 +38,7 @@
 (add-to-list 'auto-mode-alist '("\\.sbclrc$" . lisp-mode))
 
 ;; Open files with .cl extension in lisp-mode
-(add-to-list 'auto-mode-alist '("\\.cl$" . lisp-mode))
+(add-to-list 'auto-mode-alist '("\\.cl\\'" . lisp-mode))
 
 ;; Common Lisp support depends on SLIME being installed with Quicklisp
 (if (file-exists-p (expand-file-name "~/quicklisp/slime-helper.el"))


### PR DESCRIPTION
I'm surprised that this isn't already the case.
