### PR TITLE
Clisp extension

### DIFF
--- a/modules/prelude-common-lisp.el
+++ b/modules/prelude-common-lisp.el
@@ -35,7 +35,7 @@
 (require 'prelude-lisp)
 
 ;; the SBCL configuration file is in Common Lisp
-(add-to-list 'auto-mode-alist '("\\.sbclrc$" . lisp-mode))
+(add-to-list 'auto-mode-alist '("\\.sbclrc\\'" . lisp-mode))
 
 ;; Open files with .cl extension in lisp-mode
 (add-to-list 'auto-mode-alist '("\\.cl\\'" . lisp-mode))


### PR DESCRIPTION
Open files with a .cl extension in lisp mode

Correct the auto-mode-alist line for sbclrc files to have the correct terminator
