### PR TITLE
Open .podspec files in Ruby mode

### DIFF
--- a/modules/prelude-ruby.el
+++ b/modules/prelude-ruby.el
@@ -49,6 +49,7 @@
 (add-to-list 'auto-mode-alist '("Vagrantfile\\'" . ruby-mode))
 (add-to-list 'auto-mode-alist '("\\.jbuilder\\'" . ruby-mode))
 (add-to-list 'auto-mode-alist '("Podfile\\'" . ruby-mode))
+(add-to-list 'auto-mode-alist '("\\.podspec\\'" . ruby-mode))
 
 ;; We never want to edit Rubinius bytecode
 (add-to-list 'completion-ignored-extensions ".rbc")


### PR DESCRIPTION
.podspec files use a Ruby DSL for the CocoaPod dependency management
system, common in iOS development.

Although the Podspec file correctly opens in Ruby mode, the .podspec
file does not. This corrects that.
