### PR TITLE
Add ruby-mode to Puppetfiles

### DIFF
--- a/modules/prelude-ruby.el
+++ b/modules/prelude-ruby.el
@@ -50,6 +50,7 @@
 (add-to-list 'auto-mode-alist '("\\.jbuilder\\'" . ruby-mode))
 (add-to-list 'auto-mode-alist '("Podfile\\'" . ruby-mode))
 (add-to-list 'auto-mode-alist '("\\.podspec\\'" . ruby-mode))
+(add-to-list 'auto-mode-alist '("Puppetfile\\'" . ruby-mode))
 
 ;; We never want to edit Rubinius bytecode
 (add-to-list 'completion-ignored-extensions ".rbc")


### PR DESCRIPTION
Puppetfiles are similar to Gemfiles, but for librarian-puppet, that
manages dependencies on Puppet modules.
