### PR TITLE
Simplify `prelude-annotate-todo`, make it evaporate when modified.

### DIFF
--- a/core/prelude-core.el
+++ b/core/prelude-core.el
@@ -34,6 +34,7 @@
 
 (require 'thingatpt)
 (require 'dash)
+(require 'ov)
 
 (defun prelude-open-with (arg)
   "Open visited file in default external program.
@@ -176,18 +177,18 @@ point reaches the beginning or end of the buffer, stop there."
     (mark-defun)
     (indent-region (region-beginning) (region-end))))
 
+(defun prelude-todo-ov-evaporate (_ov _after _beg _end &optional _length)
+  (let ((inhibit-modification-hooks t))
+    (if _after (ov-reset _ov))))
+
 (defun prelude-annotate-todo ()
   "Put fringe marker on TODO: lines in the curent buffer."
   (interactive)
-  (save-excursion
-    (goto-char (point-min))
-    (while (re-search-forward
-            (format "[[:space:]]*%s+[[:space:]]*TODO:" comment-start) nil t)
-      (let ((overlay (make-overlay (- (point) 5) (point))))
-        (overlay-put overlay
-                     'before-string
-                     (propertize (format "A")
-                                 'display '(left-fringe right-triangle)))))))
+  (ov-set (format "[[:space:]]*%s+[[:space:]]*TODO:" comment-start)
+          'before-string
+          (propertize (format "A")
+                      'display '(left-fringe right-triangle))
+          'modification-hooks '(prelude-todo-ov-evaporate)))
 
 (defun prelude-copy-file-name-to-clipboard ()
   "Copy the current buffer file name to the clipboard."

--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -60,6 +60,7 @@
     gitignore-mode
     grizzl
     guru-mode
+    ov
     projectile
     magit
     move-text


### PR DESCRIPTION
With the help of Shingo Fukuyama's wonderful [ov.el](https://github.com/ShingoFukuyama/ov.el) package, manipulating overlays becomes much easier than ever. The "evaporating" idea was stolen from the package's example code.
