### PR TITLE
Checks for ack-grep, for Debian systems.

### DIFF
--- a/utils/installer.sh
+++ b/utils/installer.sh
@@ -166,7 +166,7 @@ else
 fi
 
 printf  "$CYAN Checking to see if ack is installed... "
-if hash ack 2>&-
+if hash ack 2>&- || hash ack-grep 2>&-
 then
     printf "$GREEN found.$RESET\n"
 else


### PR DESCRIPTION
On Debian based systems (including Ubuntu), the command for `ack` is `ack-grep`.
