### PR TITLE
Remove terrible suggestion from docstring

### DIFF
--- a/core/prelude-custom.el
+++ b/core/prelude-custom.el
@@ -71,7 +71,7 @@ Prelude recommends you only put personal customizations in the
 personal folder.  This variable allows you to specify a specific
 folder as the one that should be visited when running
 `prelude-find-user-init-file'.  This can be easily set to the desired buffer
-in lisp by putting `(setq prelude-user-init-file buffer-file-name)'
+in lisp by putting `(setq prelude-user-init-file load-file-name)'
 in the desired elisp file."
   :type 'string
   :group 'prelude)


### PR DESCRIPTION
Using buffer-filename in a loaded emacs file just DOESN'T WORK. I was wondering why my own emacs config was broken...
