### PR TITLE
Set the default directory

### DIFF
--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -48,6 +48,9 @@
 ;; delete the selection with a keypress
 (delete-selection-mode t)
 
+;; set the default directory
+(setq default-directory (getenv "HOME"))
+
 ;; store all backup and autosave files in the tmp dir
 (setq backup-directory-alist
       `((".*" . ,temporary-file-directory)))


### PR DESCRIPTION
I switch to Mac OS from Ubuntu recently. I found that the `ido-find-file` which bound to `C-x C-f` always start with the root directory `/`, while in the Ubuntu it's the HOME directory `~/`. It not convenient for finding files.
