### PR TITLE
caching passwords permanently

### DIFF
--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -182,6 +182,7 @@ The body of the advice is in BODY."
 (require 'tramp)
 ;; keep in mind known issues with zsh - see emacs wiki
 (setq tramp-default-method "ssh")
+(setq password-cache-expiry nil)         ; caching passwords permanently
 
 (set-default 'imenu-auto-rescan t)
 


### PR DESCRIPTION
TRAMP will caches the passwords entered by the user, but it's not permanently. This is customise by the `password-cache-expiry` variable which default value is 16 seconds.

I am not sure of the permanently lifetime is suitable.
