### PR TITLE
Create go mode and fix whitespace issues

### DIFF
--- a/modules/prelude-c.el
+++ b/modules/prelude-c.el
@@ -46,7 +46,8 @@
                                 (run-hooks 'prelude-c-mode-common-hook)))
 
 (defun prelude-makefile-mode-defaults ()
-  (setq indent-tabs-mode t))
+  (whitespace-toggle-options '(tabs))
+  (setq indent-tabs-mode t ))
 
 (setq prelude-makefile-mode-hook 'prelude-makefile-mode-defaults)
 


### PR DESCRIPTION
Fixes #382.
We set additional whitespace mode options in the local buffers for both Go files and c makefiles so that the tabs aren't highlighted. 
Layout of the file taken from other module files, let me know what you think.
