### PR TITLE
Remove documentation of obsolete prelude-markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,6 @@ By default most of the modules that ship with Prelude are not loaded. For more i
 (require 'prelude-js)
 ;; (require 'prelude-latex)
 (require 'prelude-lisp)
-;; (require 'prelude-markdown)
 ;; (require 'prelude-mediawiki)
 (require 'prelude-org)
 (require 'prelude-perl)


### PR DESCRIPTION
Removed noted in #428
