### PR TITLE
Rename buffer not visiting files

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Keybinding         | Description
 <kbd>C-c D</kbd> | Delete current file and buffer.
 <kbd>C-c d</kbd> | Duplicate the current line (or region).
 <kbd>C-c M-d</kbd> | Duplicate and comment the current line (or region).
-<kbd>C-c r</kbd> | Rename the currently visited file and buffer.
+<kbd>C-c r</kbd> | Rename the current buffer and its visiting file if any.
 <kbd>C-c t</kbd> | Open a terminal emulator (`ansi-term`).
 <kbd>C-c k</kbd> | Kill all open buffers except the one you're currently in.
 <kbd>C-c TAB</kbd> | Indent and copy region to clipboard

--- a/core/prelude-core.el
+++ b/core/prelude-core.el
@@ -251,12 +251,12 @@ there's a region, all lines that region covers will be duplicated."
         (setq end (point))))
     (goto-char (+ origin (* (length region) arg) arg))))
 
-(defun prelude-rename-file-and-buffer ()
-  "Renames current buffer and file it is visiting."
+(defun prelude-rename-buffer-and-file ()
+  "Rename current buffer and if the buffer is visiting a file, rename it too."
   (interactive)
   (let ((filename (buffer-file-name)))
     (if (not (and filename (file-exists-p filename)))
-        (message "Buffer is not visiting a file!")
+        (rename-buffer (read-from-minibuffer "New name: " (buffer-name)))
       (let ((new-name (read-file-name "New name: " filename)))
         (cond
          ((vc-backend filename) (vc-rename-file filename new-name))
@@ -434,7 +434,7 @@ Doesn't mess with special buffers."
     "Press <C-c G> to search in GitHub."
     "Press <C-c y> to search in YouTube."
     "Press <C-c U> to search in DuckDuckGo."
-    "Press <C-c r> to rename the current buffer and file it's visiting."
+    "Press <C-c r> to rename the current buffer and the file it's visiting if any."
     "Press <C-c t> to open a terminal in Emacs."
     "Press <C-c k> to kill all the buffers, but the active one."
     "Press <C-x g> or <s-m> to run magit-status."

--- a/core/prelude-mode.el
+++ b/core/prelude-mode.el
@@ -58,7 +58,7 @@
     (define-key map (kbd "C-c D") 'prelude-delete-file-and-buffer)
     (define-key map (kbd "C-c d") 'prelude-duplicate-current-line-or-region)
     (define-key map (kbd "C-c M-d") 'prelude-duplicate-and-comment-current-line-or-region)
-    (define-key map (kbd "C-c r") 'prelude-rename-file-and-buffer)
+    (define-key map (kbd "C-c r") 'prelude-rename-buffer-and-file)
     (define-key map (kbd "C-c t") 'prelude-visit-term-buffer)
     (define-key map (kbd "C-c k") 'prelude-kill-other-buffers)
     (define-key map (kbd "C-c TAB") 'prelude-indent-rigidly-and-copy-to-clipboard)
@@ -89,7 +89,7 @@
                         ("Files"
                          ["Open with..." prelude-open-with]
                          ["Delete file and buffer" prelude-delete-file-and-buffer]
-                         ["Rename file and buffer" prelude-rename-file-and-buffer]
+                         ["Rename buffer and file" prelude-rename-buffer-and-file]
                          ["Copy file name to clipboard" prelude-copy-file-name-to-clipboard])
 
                         ("Buffers"


### PR DESCRIPTION
Make `prelude-rename-file-and-buffer` work with buffers not visiting files.
