### PR TITLE
Extra newline and indent when RETURN between {}

### DIFF
--- a/modules/prelude-programming.el
+++ b/modules/prelude-programming.el
@@ -121,6 +121,9 @@ This functions should be added to the hooks of major modes for programming."
   (when prelude-guru
     (guru-mode +1))
   (smartparens-mode +1)
+  (sp-pair "{" nil :post-handlers
+           '(((lambda (&rest _ignored)
+                (prelude-smart-open-line-above)) "RET")))
   (prelude-enable-whitespace)
   (prelude-local-comment-auto-fill)
   (prelude-font-lock-comment-annotations))


### PR DESCRIPTION
See #565
