### PR TITLE
Remap ace-window to M-p.

### DIFF
--- a/core/prelude-global-keybindings.el
+++ b/core/prelude-global-keybindings.el
@@ -120,7 +120,7 @@
 (global-set-key (kbd "C-c J") 'ace-jump-buffer)
 (global-set-key (kbd "s->") 'ace-jump-buffer)
 
-(global-set-key [remap other-window] 'ace-window)
+(global-set-key (kbd "M-p") 'ace-window)
 
 (provide 'prelude-global-keybindings)
 


### PR DESCRIPTION
Preserve C-o behavior. M-p is suggested on the [ace-window documentation](https://github.com/abo-abo/ace-window/tree/18f300a404d4942f3d5f393db2e6ceee71b3c704#setup).
