### PR TITLE
Avoid compile warning in test for slime

### DIFF
--- a/modules/prelude-common-lisp.el
+++ b/modules/prelude-common-lisp.el
@@ -68,7 +68,7 @@
 
 (defun prelude-start-slime ()
   "Start SLIME unless it's already running."
-  (unless (slime-connected-p)
+  (unless (and (fboundp 'slime-connected-p) (slime-connected-p))
     (save-excursion (slime))))
 
 ;; start slime automatically when we open a lisp file


### PR DESCRIPTION
Checking if the function exists before trying to use it avoids a warning at startup when not defined.
