### PR TITLE
Do not deactivate-mark if region active when exchange-point-and-mark

### DIFF
--- a/core/prelude-core.el
+++ b/core/prelude-core.el
@@ -469,11 +469,6 @@ Doesn't mess with special buffers."
     (when after-init-time
       (eval form))))
 
-(defun prelude-exchange-point-and-mark ()
-  "Identical to `exchange-point-and-mark' but will not activate the region."
-  (interactive)
-  (exchange-point-and-mark (not (region-active-p))))
-
 (require 'epl)
 
 (defun prelude-update ()

--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -280,6 +280,11 @@ The body of the advice is in BODY."
 (browse-kill-ring-default-keybindings)
 (global-set-key (kbd "s-y") 'browse-kill-ring)
 
+(defadvice exchange-point-and-mark (before deactivate-mark activate compile)
+  "When called with no active region, do not activate mark."
+  (interactive
+   (list (not (region-active-p)))))
+
 ;; automatically indenting yanked text if in programming-modes
 (defvar yank-indent-modes
   '(LaTeX-mode TeX-mode)

--- a/core/prelude-global-keybindings.el
+++ b/core/prelude-global-keybindings.el
@@ -110,11 +110,6 @@
 
 (global-set-key (kbd "C-=") 'er/expand-region)
 
-;; make C-x C-x usable with transient-mark-mode
-(define-key global-map
-  [remap exchange-point-and-mark]
-  'prelude-exchange-point-and-mark)
-
 (global-set-key (kbd "C-c j") 'ace-jump-mode)
 (global-set-key (kbd "s-.") 'ace-jump-mode)
 (global-set-key (kbd "C-c J") 'ace-jump-buffer)


### PR DESCRIPTION
From the emacs official documentation:

> The command `C-x C-x' (`exchange-point-and-mark') exchanges the
> positions of point and the mark.  `C-x C-x' is useful when you are
> satisfied with the position of point but want to move the other end of
> the region (where the mark is).

We should preserve this feature with `prelude-exchange-point-and-mark`,
when the function is called with an active region, I think, we should
not deactivate the mark.
