### PR TITLE
Add note about .emacs.d Windows path

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ ln -s path/to/local/repo ~/.emacs.d
 cd ~/.emacs.d
 ```
 
-Note that on Windows, the `.emacs.d` directory is usually located at `C:\Users\your_user_name\AppData\Roaming\.emacs.d`, and you should adjust the command appropriately.
+If you are using Windows, you should check what Emacs thinks the `~` directory is by running Emacs and typing `C-x d ~/<RET>`, and then adjust the command appropriately.
 
 ## Updating Prelude
 


### PR DESCRIPTION
At least on my Windows 7 machine, `user-emacs-directory` prints `~/.emacs.d`, which is not really useful, since you also then have to realize that the tilde refers to the roaming appdata directory. I think this way of documenting would perhaps be more immediately useful. For probably almost all other platforms the tilde path will work just fine.
