### PR TITLE
Make web-mode play nice with smartparens

### DIFF
--- a/modules/prelude-web.el
+++ b/modules/prelude-web.el
@@ -49,11 +49,25 @@
 (eval-after-load 'web-mode
   '(progn
      (defun prelude-web-mode-defaults ()
-       )
+       ;; make web-mode play nice with smartparens
+       (setq web-mode-enable-auto-pairing nil)
+       (sp-with-modes '(web-mode)
+         (sp-local-pair "%" "%"
+                        :unless '(sp-in-string-p)
+                        :post-handlers '(((lambda (&rest _ignored)
+                                            (just-one-space)
+                                            (save-excursion (insert " ")))
+                                          "SPC" "=" "#")))
+         (sp-local-pair "<% "  " %>" :insert "C-c %")
+         (sp-local-pair "<%= " " %>" :insert "C-c =")
+         (sp-local-pair "<%# " " %>" :insert "C-c #")
+         (sp-local-tag "%" "<% "  " %>")
+         (sp-local-tag "=" "<%= " " %>")
+         (sp-local-tag "#" "<%# " " %>")))
      (setq prelude-web-mode-hook 'prelude-web-mode-defaults)
 
      (add-hook 'web-mode-hook (lambda ()
-                                 (run-hooks 'prelude-web-mode-hook)))))
+                                (run-hooks 'prelude-web-mode-hook)))))
 
 (provide 'prelude-web)
 ;;; prelude-web.el ends here


### PR DESCRIPTION
web-mode's auto paring is in conflict with smartparens. With
smartparens, since the closing '>' is inserted right after the opening
'<' and web-mode is not aware of that, the extra closing '>' would be
inserted. That's very annoying.
