### PR TITLE
Run prelude-prog-mode-hook with CSS

### DIFF
--- a/modules/prelude-css.el
+++ b/modules/prelude-css.el
@@ -38,7 +38,8 @@
 
      (defun prelude-css-mode-defaults ()
        (setq css-indent-offset 2)
-       (rainbow-mode +1))
+       (rainbow-mode +1)
+       (run-hooks 'prelude-prog-mode-hook))
 
      (setq prelude-css-mode-hook 'prelude-css-mode-defaults)
 


### PR DESCRIPTION
I don't know if CSS should be count as a programming language, but the
utilities provided in the `prelude-prog-mode-hook`, such as
smartparens, whitespace-mode, comment annotation, are also very useful
when editing CSS files.
