### PR TITLE
Fix go-oracle-mode path

### DIFF
--- a/modules/prelude-go.el
+++ b/modules/prelude-go.el
@@ -84,7 +84,8 @@
      (let ((oracle (executable-find "oracle")))
        (when oracle
          (setq go-oracle-command oracle)
-         (autoload 'go-oracle-mode "oracle")
+         (go-projectile-tools-add-path)
+         (autoload 'go-oracle-mode "oracle.el")
          (add-hook 'go-mode-hook 'go-oracle-mode)))))
 
 (provide 'prelude-go)


### PR DESCRIPTION
This will fix loading the oracle.el file which is included when you install oracle. Defining $GOPATH is part of a typical go installation, so relying on it should be ok. Not sure if there is a more robust way to locate the oracle.el file.
