### PR TITLE
Move smartparens pair definition out of hooks

### DIFF
--- a/modules/prelude-programming.el
+++ b/modules/prelude-programming.el
@@ -113,6 +113,11 @@ This functions should be added to the hooks of major modes for programming."
 ;;
 ;; (the final optional t sets the *append* argument)
 
+;; smart curly braces
+(sp-pair "{" nil :post-handlers
+         '(((lambda (&rest _ignored)
+              (prelude-smart-open-line-above)) "RET")))
+
 (defun prelude-prog-mode-defaults ()
   "Default coding hook, useful with any programming language."
   (when (and (executable-find ispell-program-name)
@@ -121,9 +126,6 @@ This functions should be added to the hooks of major modes for programming."
   (when prelude-guru
     (guru-mode +1))
   (smartparens-mode +1)
-  (sp-pair "{" nil :post-handlers
-           '(((lambda (&rest _ignored)
-                (prelude-smart-open-line-above)) "RET")))
   (prelude-enable-whitespace)
   (prelude-local-comment-auto-fill)
   (prelude-font-lock-comment-annotations))

--- a/modules/prelude-web.el
+++ b/modules/prelude-web.el
@@ -34,6 +34,8 @@
 
 (prelude-require-packages '(web-mode))
 
+(require 'web-mode)
+
 (add-to-list 'auto-mode-alist '("\\.phtml\\'" . web-mode))
 (add-to-list 'auto-mode-alist '("\\.tpl\\.php\\'" . web-mode))
 (add-to-list 'auto-mode-alist '("\\.blade\\.php\\'" . web-mode))
@@ -44,26 +46,26 @@
 (add-to-list 'auto-mode-alist
 '("/\\(views\\|html\\|theme\\|templates\\)/.*\\.php\\'" . web-mode))
 
+;; make web-mode play nice with smartparens
+(setq web-mode-enable-auto-pairing nil)
 
+(sp-with-modes '(web-mode)
+  (sp-local-pair "%" "%"
+                 :unless '(sp-in-string-p)
+                 :post-handlers '(((lambda (&rest _ignored)
+                                     (just-one-space)
+                                     (save-excursion (insert " ")))
+                                   "SPC" "=" "#")))
+  (sp-local-pair "<% "  " %>" :insert "C-c %")
+  (sp-local-pair "<%= " " %>" :insert "C-c =")
+  (sp-local-pair "<%# " " %>" :insert "C-c #")
+  (sp-local-tag "%" "<% "  " %>")
+  (sp-local-tag "=" "<%= " " %>")
+  (sp-local-tag "#" "<%# " " %>"))
 
 (eval-after-load 'web-mode
   '(progn
-     (defun prelude-web-mode-defaults ()
-       ;; make web-mode play nice with smartparens
-       (setq web-mode-enable-auto-pairing nil)
-       (sp-with-modes '(web-mode)
-         (sp-local-pair "%" "%"
-                        :unless '(sp-in-string-p)
-                        :post-handlers '(((lambda (&rest _ignored)
-                                            (just-one-space)
-                                            (save-excursion (insert " ")))
-                                          "SPC" "=" "#")))
-         (sp-local-pair "<% "  " %>" :insert "C-c %")
-         (sp-local-pair "<%= " " %>" :insert "C-c =")
-         (sp-local-pair "<%# " " %>" :insert "C-c #")
-         (sp-local-tag "%" "<% "  " %>")
-         (sp-local-tag "=" "<%= " " %>")
-         (sp-local-tag "#" "<%# " " %>")))
+     (defun prelude-web-mode-defaults ())
      (setq prelude-web-mode-hook 'prelude-web-mode-defaults)
 
      (add-hook 'web-mode-hook (lambda ()


### PR DESCRIPTION
There are two reasons for doing this:
- It's inefficient, we don't have to define the pairs every time we
  enter the mode.
- It's extremely difficult to override the pair definition, even with
  `eval-after-load` and `add-hook`
