### PR TITLE
Look for Quicklisp in ~/quicklisp and ~/.quicklisp

### DIFF
--- a/modules/prelude-common-lisp.el
+++ b/modules/prelude-common-lisp.el
@@ -41,9 +41,11 @@
 (add-to-list 'auto-mode-alist '("\\.cl\\'" . lisp-mode))
 
 ;; Common Lisp support depends on SLIME being installed with Quicklisp
-(if (file-exists-p (expand-file-name "~/quicklisp/slime-helper.el"))
-    (load (expand-file-name "~/quicklisp/slime-helper.el"))
-  (message "%s" "SLIME is not installed. Use Quicklisp to install it."))
+(cond ((file-exists-p (expand-file-name "~/quicklisp/slime-helper.el"))
+       (load (expand-file-name "~/quicklisp/slime-helper.el")))
+      ((file-exists-p (expand-file-name "~/.quicklisp/slime-helper.el"))
+       (load (expand-file-name "~/.quicklisp/slime-helper.el")))
+      (t (message "%s" "SLIME is not installed. Use Quicklisp to install it.")))
 
 ;; a list of alternative Common Lisp implementations that can be
 ;; used with SLIME. Note that their presence render


### PR DESCRIPTION
In `prelude-common-lisp.el`, look in both `~/quicklisp/` and
`~/.quicklisp/` for `slime-helper.el`, on the assumption that most users
will have Quicklisp installed in one of these two locations.

This commit fixes #582
