### PR TITLE
Add fast math entry methods

### DIFF
--- a/modules/prelude-latex.el
+++ b/modules/prelude-latex.el
@@ -32,13 +32,24 @@
 
 ;;; Code:
 
-(prelude-require-packages '(auctex))
+(prelude-require-packages '(auctex cdlatex))
 (require 'smartparens-latex)
+;; for case
+(require 'cl)
 
 (eval-after-load "company"
   '(progn
      (prelude-require-packages '(company-auctex))
      (company-auctex-init)))
+
+(defcustom prelude-latex-fast-math-entry 'LaTeX-math-mode
+  "Method used for fast math symbol entry in LaTeX."
+  :link '(function-link :tag "AUCTeX Math Mode" LaTeX-math-mode)
+  :link '(emacs-commentary-link :tag "CDLaTeX" "cdlatex.el")
+  :group 'prelude
+  :type '(choice (const :tag "None" nil)
+                 (const :tag "AUCTeX Math Mode" LaTeX-math-mode)
+                 (const :tag "CDLaTeX" cdlatex)))
 
 ;; AUCTeX configuration
 (setq TeX-auto-save t)
@@ -65,7 +76,10 @@
   "Default Prelude hook for `LaTeX-mode'."
   (turn-on-auto-fill)
   (abbrev-mode +1)
-  (smartparens-mode +1))
+  (smartparens-mode +1)
+  (case prelude-latex-fast-math-entry
+    (LaTeX-math-mode (LaTeX-math-mode 1))
+    (cdlatex (turn-on-cdlatex))))
 
 (setq prelude-latex-mode-hook 'prelude-latex-mode-defaults)
 


### PR DESCRIPTION
Enable LaTeX-math-mode by default and allow the user to select between it and CDLaTeX.
