### PR TITLE
fix for evil-mode in terminal

### DIFF
--- a/modules/prelude-evil.el
+++ b/modules/prelude-evil.el
@@ -48,6 +48,9 @@
 (setq evil-insert-state-cursor '("gray" bar))
 (setq evil-motion-state-cursor '("gray" box))
 
+;; prevent esc-key from translating to meta-key in terminal mode
+(setq evil-esc-delay 0)
+
 (evil-mode 1)
 (global-evil-surround-mode 1)
 


### PR DESCRIPTION
Hi bbatsov,

evil-mode in the terminal has an issue where if you type esc-key really fast it is translated as meta-key. This is obviously super bad and makes using evil-mode in the terminal not useful. Setting it to 0 fixes this issue and the meta key still works.
