### PR TITLE
prelude-ocaml fix

### DIFF
--- a/modules/prelude-ocaml.el
+++ b/modules/prelude-ocaml.el
@@ -38,8 +38,6 @@
 (require 'utop)
 (require 'merlin)
 
-(add-hook 'tuareg-mode-hook 'tuareg-imenu-set-imenu)
-
 (setq auto-mode-alist
       (append '(("\\.ml[ily]?\\'" . tuareg-mode)
                 ("\\.topml\\'" . tuareg-mode))


### PR DESCRIPTION
Activate company mode support in merlin, and remove the hook that is causing an error as described in issue #614.
