### PR TITLE
Fix editing remote unwriteable file

### DIFF
--- a/core/prelude-core.el
+++ b/core/prelude-core.el
@@ -303,11 +303,10 @@ buffer is not visiting a file."
 
 (defadvice ido-find-file (after find-file-sudo activate)
   "Find file as root if necessary."
-  (unless (or (equal major-mode 'dired-mode)
-              (and (buffer-file-name)
-                   (not (file-exists-p (file-name-directory (buffer-file-name)))))
-              (and (buffer-file-name)
-                   (file-writable-p buffer-file-name)))
+  (unless (or (tramp-tramp-file-p buffer-file-name)
+              (equal major-mode 'dired-mode)
+              (not (file-exists-p (file-name-directory buffer-file-name)))
+              (file-writable-p buffer-file-name))
     (find-alternate-file (concat "/sudo:root@localhost:" buffer-file-name))))
 
 (defun prelude-start-or-switch-to (function buffer-name)


### PR DESCRIPTION
With the original advice, if we try to find a not writeable file on a remote machine, the extra tramp prefix would be inserted, As a result, we actually end up in a blank new file. For example, I was trying to find the hosts file on a remote machine named theoden:

```
File not `/sudo:root@localhost:/ssh:theoden:/etc/hosts' found on remote host
```

Since we'er advising `ido-find-file`, I suppose `buffer-file-name` will always return something except we'er finding a directory, which has already been checked in the second clause, so I think the `buffer-file-name` check can be safely removed, right?
