### PR TITLE
Toggle comment on current line easily.

### DIFF
--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -298,6 +298,17 @@ The body of the advice is in BODY."
 (with-region-or-buffer indent-region)
 (with-region-or-buffer untabify)
 
+(defmacro with-region-or-line (func)
+  "When called with no active region, call FUNC on current line."
+  `(defadvice ,func (before with-region-or-line activate compile)
+     (interactive
+      (if mark-active
+          (list (region-beginning) (region-end))
+        (list (line-beginning-position)
+              (line-beginning-position 2))))))
+
+(with-region-or-line comment-or-uncomment-region)
+
 ;; automatically indenting yanked text if in programming-modes
 (defun yank-advised-indent-function (beg end)
   "Do indentation, as long as the region isn't too large."

--- a/core/prelude-global-keybindings.el
+++ b/core/prelude-global-keybindings.el
@@ -86,6 +86,9 @@
 
 (global-set-key [remap kill-whole-line] 'prelude-kill-whole-line)
 
+;; toggle comment on current line
+(global-set-key (kbd "s-;") 'comment-or-uncomment-region)
+
 ;; Activate occur easily inside isearch
 (define-key isearch-mode-map (kbd "C-o")
   (lambda () (interactive)


### PR DESCRIPTION
This functionality is present in almost every modern editors and IDEs, textmate, sublime for example, the conventional key binding is <kbd>s-/</kbd>. It's so ubiquitous that online websites like JSBin, JSFiddle has this shortcut build in their code editors. I have brought this up in #332 and recently someone else argues the same #600.

Since <kbd>s-/</kbd> is already bound to `hippie-expand`, I think <kbd>s-;</kbd> is also a good key binding, it's quite similar to the binding of `comment-dwim`  <kbd>M-;</kbd>.
