### PR TITLE
Update global keymap documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Keybinding         | Description
 <kbd>C-c . -</kbd> | Decrement integer at point. Default is -1.
 <kbd>C-c . *</kbd> | Multiply integer at point. Default is *2.
 <kbd>C-c . /</kbd> | Divide integer at point. Default is /2.
-<kbd>C-c . \</kbd> | Modulo integer at point. Default is modulo 2.
+<kbd>C-c . \\</kbd> | Modulo integer at point. Default is modulo 2.
 <kbd>C-c . ^</kbd> | Power to the integer at point. Default is ^2.
 <kbd>C-c . <</kbd> | Left-shift integer at point. Default is 1 position to the left.
 <kbd>C-c . ></kbd> | Right-shift integer at point. Default is 1 position to the right.


### PR DESCRIPTION
The <kbd>C-M-h</kbd> keybinding has been removed in commit 3ac3415, so I removed it from the README.md.

Also, there was a backslash escaping issue with the <kbd>C-c . \</kbd> keybinding documentation when rendered in Markdown, which I fixed.
