### PR TITLE
Improve Helm configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,6 @@ Keybinding         | Description
 <kbd>C-c t</kbd> | Open a terminal emulator (`ansi-term`).
 <kbd>C-c k</kbd> | Kill all open buffers except the one you're currently in.
 <kbd>C-c TAB</kbd> | Indent and copy region to clipboard
-<kbd>C-c h</kbd> | Open Helm (available if you've enabled the `prelude-helm` module).
 <kbd>C-c I</kbd> | Open user's init file.
 <kbd>C-c S</kbd> | Open shell's init file.
 <kbd>C-c . +</kbd> | Increment integer at point. Default is +1.
@@ -368,6 +367,14 @@ Prelude adds an extra keymap prefix `S-p` (`S` stands for
 If you ever forget any of Projectile's keybindings just do a:
 
 <kbd>C-c p C-h</kbd>
+
+#### Helm
+
+Helm is setup according to this guide: [A Package in a league of its own: Helm](http://tuhdo.github.io/helm-intro.html).
+
+You can learn Helm usage and key bindings following the guide. <kbd>C-c h</kbd>
+is Prelude's default prefix key for Helm. If you don't remember any key binding,
+append <kbd>C-h</kbd> after <kbd>C-c h</kbd> for a list of key bindings in Helm.
 
 #### Key-chords
 

--- a/modules/prelude-helm.el
+++ b/modules/prelude-helm.el
@@ -32,30 +32,92 @@
 
 ;;; Code:
 
-(prelude-require-packages '(helm helm-projectile))
+(prelude-require-packages '(helm helm-projectile helm-descbinds))
 
-(require 'helm-misc)
+(require 'helm)
+
+;; must set before helm-config,  otherwise helm use default
+;; prefix "C-x c", which is inconvenient because you can
+;; accidentially pressed "C-x C-c"
+(setq helm-command-prefix-key "C-c h")
+
+(require 'helm-config)
+(require 'helm-eshell)
+(require 'helm-files)
+(require 'helm-grep)
+
+(define-key helm-map (kbd "<tab>") 'helm-execute-persistent-action) ; rebihnd tab to do persistent action
+(define-key helm-map (kbd "C-i") 'helm-execute-persistent-action) ; make TAB works in terminal
+(define-key helm-map (kbd "C-z")  'helm-select-action) ; list actions using C-z
+
+(define-key helm-grep-mode-map (kbd "<return>")  'helm-grep-mode-jump-other-window)
+(define-key helm-grep-mode-map (kbd "n")  'helm-grep-mode-jump-other-window-forward)
+(define-key helm-grep-mode-map (kbd "p")  'helm-grep-mode-jump-other-window-backward)
+
+(setq
+ helm-google-suggest-use-curl-p t
+ helm-scroll-amount 4 ; scroll 4 lines other window using M-<next>/M-<prior>
+ helm-quick-update t ; do not display invisible candidates
+ helm-idle-delay 0.01 ; be idle for this many seconds, before updating in delayed sources.
+ helm-input-idle-delay 0.01 ; be idle for this many seconds, before updating candidate buffer
+ helm-ff-search-library-in-sexp t ; search for library in `require' and `declare-function' sexp.
+ helm-split-window-default-side 'other ;; open helm buffer in another window
+ helm-split-window-in-side-p t ;; open helm buffer inside current window, not occupy whole other window
+ helm-buffers-favorite-modes (append helm-buffers-favorite-modes
+				     '(picture-mode artist-mode))
+ helm-candidate-number-limit 500 ; limit the number of displayed canidates
+ helm-M-x-requires-pattern 0	 ; show all candidates when set to 0
+ helm-ff-file-name-history-use-recentf t
+ helm-move-to-line-cycle-in-source t ; move to end or beginning of source
+                                        ; when reaching top or bottom of source.
+ ido-use-virtual-buffers t		; Needed in helm-buffers-list
+ helm-buffers-fuzzy-matching t          ; fuzzy matching buffer names when non-nil
+                                        ; useful in helm-mini that lists buffers
+ )
+
+(global-set-key (kbd "M-x") 'helm-M-x)
+(global-set-key (kbd "M-y") 'helm-show-kill-ring)
+(global-set-key (kbd "C-x b") 'helm-mini)
+(global-set-key (kbd "C-x C-f") 'helm-find-files)
+(global-set-key (kbd "C-h SPC") 'helm-all-mark-rings)
+(global-set-key (kbd "C-c h o") 'helm-occur)
+(global-set-key (kbd "C-c h g") 'helm-do-grep)
+(global-set-key (kbd "C-c h C-c w") 'helm-wikipedia-suggest)
+(global-set-key (kbd "C-c h x") 'helm-register)
+
+(define-key 'help-command (kbd "C-f") 'helm-apropos)
+(define-key 'help-command (kbd "r") 'helm-info-emacs)
+(define-key 'help-command (kbd "C-l") 'helm-locate-library)
+
+;; use helm to list eshell history
+(add-hook 'eshell-mode-hook
+          #'(lambda ()
+              (define-key eshell-mode-map (kbd "M-l")  'helm-eshell-history)))
+
+;;; Save current position to mark ring
+(add-hook 'helm-goto-line-before-hook 'helm-save-current-pos-to-mark-ring)
+
+;; show minibuffer history with Helm
+(define-key minibuffer-local-map (kbd "M-p") 'helm-minibuffer-history)
+(define-key minibuffer-local-map (kbd "M-n") 'helm-minibuffer-history)
+
+(define-key global-map [remap find-tag] 'helm-etags-select)
+(define-key global-map [remap list-buffers] 'helm-buffers-list)
+
+(define-key shell-mode-map (kbd "M-p") 'helm-comint-input-ring) ; shell history.
+
 (require 'helm-projectile)
+(setq projectile-completion-system 'helm)
 
-(defun helm-prelude ()
-  "Preconfigured `helm'."
-  (interactive)
-  (condition-case nil
-      (if (projectile-project-root)
-          (helm-projectile)
-        ;; otherwise fallback to `helm-mini'
-        (helm-mini))
-    ;; fall back to helm mini if an error occurs (usually in `projectile-project-root')
-    (error (helm-mini))))
+(push "Press <C-c p h> to navigate a project in Helm." prelude-tips)
 
-(eval-after-load 'prelude-mode
-  '(progn
-     (define-key prelude-mode-map (kbd "C-c h") 'helm-prelude)
-     (easy-menu-add-item nil '("Tools" "Prelude")
-                         '("Navigation"
-                           ["Helm" helm-prelude]))))
-
-(push "Press <C-c h> to navigate a project in Helm." prelude-tips)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; PACKAGE: helm-descbinds                      ;;
+;;                                              ;;
+;; GROUP: Convenience -> Helm -> Helm Descbinds ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(require 'helm-descbinds)
+(helm-descbinds-mode)
 
 (provide 'prelude-helm)
 


### PR DESCRIPTION
The current prelude-helm only uses a single command of Helm, which
is a waste given how Helm contains many other commands. When
prelude-helm is activated, users should be able to utilize all of these
useful commands. If a user wants to use Helm, he will want to use all of
its features anyway.

`prelude-helm` is configured that it is able to be used with this [guide](http://tuhdo.github.io/helm-intro.html). If this got merged, I can put a link from my guide for readers to download and use Prelude for trying out Helm.
