### PR TITLE
Flat index with python imenu

### DIFF
--- a/modules/prelude-python.el
+++ b/modules/prelude-python.el
@@ -45,8 +45,8 @@
              buffer-file-coding-system)))
     (if coding-system
         (symbol-name
-              (or (coding-system-get coding-system 'mime-charset)
-                  (coding-system-change-eol-conversion coding-system nil)))
+         (or (coding-system-get coding-system 'mime-charset)
+             (coding-system-change-eol-conversion coding-system nil)))
       "ascii-8bit")))
 
 (defun prelude-python--insert-coding-comment (encoding)
@@ -78,9 +78,12 @@
   "Defaults for Python programming."
   (subword-mode +1)
   (setq-local electric-layout-rules
-	      '((?: . (lambda ()
+              '((?: . (lambda ()
                         (if (python-info-statement-starts-block-p)
                             'after)))))
+  (when (fboundp #'python-imenu-create-flat-index)
+    (setq-local imenu-create-index-function
+                #'python-imenu-create-flat-index))
   (electric-layout-mode +1)
   (add-hook 'after-save-hook 'prelude-python-mode-set-encoding nil 'local))
 


### PR DESCRIPTION
Tree structure imenu index does not play nice with
`prelude-ido-goto-symbol`, for example with the following python code:

``` python
class A(object):
    def __init__():
        pass

class B(A):
    def __init__():
        pass
```

The current `prelude-ido-goto-symbol` can only recognize one `__init__`
