### PR TITLE
Allow enable/disable global helm key bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,9 +372,35 @@ If you ever forget any of Projectile's keybindings just do a:
 
 Helm is setup according to this guide: [A Package in a league of its own: Helm](http://tuhdo.github.io/helm-intro.html).
 
-You can learn Helm usage and key bindings following the guide. <kbd>C-c h</kbd>
-is Prelude's default prefix key for Helm. If you don't remember any key binding,
-append <kbd>C-h</kbd> after <kbd>C-c h</kbd> for a list of key bindings in Helm.
+You can learn Helm usage and key bindings following the guide. <kbd>C-c h</kbd> is Prelude's default prefix key for Helm.
+If you don't remember any key binding, append <kbd>C-h</kbd> after <kbd>C-c h</kbd> for a list of key bindings in Helm.
+
+By default, Helm won't activate these global key bindings, so you can use Helm along with Ido and Prelude's default commands:
+
+Key binding        | Description
+-------------------|----------------------------------------------
+<kbd>M-x</kbd>     | Run [helm-M-x](http://tuhdo.github.io/helm-intro.html#sec-3), an interactive version of <kbd>M-x</kdb>.
+<kbd>M-y</kbd>     | Run [helm-show-kill-ring](http://tuhdo.github.io/helm-intro.html#sec-4), shows the content of `kill-ring`.
+<kbd>C-x b </kbd>  | Run [helm-mini](http://tuhdo.github.io/helm-intro.html#sec-5), an interactive version of `C-x b` with more features.
+<kbd>C-x C-f</kbd> | Run [helm-find-files](http://tuhdo.github.io/helm-intro.html#sec-6), an interactive version of `find-file` with more features.
+<kbd>C-h C-f </kbd>| Run [helm-apropos](http://tuhdo.github.io/helm-intro.html#sec-13), an interactive version of `apropos-command`.
+<kbd>C-h r</kbd>   | Run [helm-info-emacs](http://tuhdo.github.io/helm-intro.html#sec-14), an interactive version of `info-emacs-manual`.
+<kbd>C-h C-l </kbd>| Run `helm-locate-library` that can search for locations of any file loaded into Emacs.
+
+This key binding won't be activated in `shell-mode`:
+
+Key Binding        | Description
+-------------------|----------------------------------------------
+<kbd>M-l</kbd>     | Run `helm-comint-input-ring` that shows `shell` history using Helm interface.
+
+These key bindings won't be activated in `eshell-mode`:
+
+Key Binding        | Description
+-------------------|----------------------------------------------
+<kbd>M-l</kbd>     | Run `helm-eshell-history` that shows `eshell` history using Helm interface.
+
+You can use above key bindings by putting `(prelude-global-helm-global-mode +1)` right after `(require 'prelude-helm)`. If you enable
+these key bindings, you should not enable `prelude-ido`.
 
 #### Key-chords
 

--- a/modules/prelude-helm.el
+++ b/modules/prelude-helm.el
@@ -1,6 +1,6 @@
 ;;; prelude-helm.el --- Helm setup
 ;;
-;; Copyright © 2011-2013 Bozhidar Batsov
+;; Copyright © 2011-2014 Bozhidar Batsov
 ;;
 ;; Author: Bozhidar Batsov <bozhidar@batsov.com>
 ;; URL: https://github.com/bbatsov/prelude
@@ -11,7 +11,7 @@
 
 ;;; Commentary:
 
-;; Some config for Helm.
+;; Some config for Helm that follows thiks guide: http://tuhdo.github.io/helm-intro.html
 
 ;;; License:
 
@@ -64,58 +64,76 @@
  helm-split-window-default-side 'other ;; open helm buffer in another window
  helm-split-window-in-side-p t ;; open helm buffer inside current window, not occupy whole other window
  helm-buffers-favorite-modes (append helm-buffers-favorite-modes
-				     '(picture-mode artist-mode))
+                                     '(picture-mode artist-mode))
  helm-candidate-number-limit 500 ; limit the number of displayed canidates
- helm-M-x-requires-pattern 0	 ; show all candidates when set to 0
+ helm-M-x-requires-pattern 0    ; show all candidates when set to 0
  helm-ff-file-name-history-use-recentf t
  helm-move-to-line-cycle-in-source t ; move to end or beginning of source
                                         ; when reaching top or bottom of source.
- ido-use-virtual-buffers t		; Needed in helm-buffers-list
+ ido-use-virtual-buffers t             ; Needed in helm-buffers-list
  helm-buffers-fuzzy-matching t          ; fuzzy matching buffer names when non-nil
                                         ; useful in helm-mini that lists buffers
  )
 
-(global-set-key (kbd "M-x") 'helm-M-x)
-(global-set-key (kbd "M-y") 'helm-show-kill-ring)
-(global-set-key (kbd "C-x b") 'helm-mini)
-(global-set-key (kbd "C-x C-f") 'helm-find-files)
-(global-set-key (kbd "C-h SPC") 'helm-all-mark-rings)
 (global-set-key (kbd "C-c h o") 'helm-occur)
 (global-set-key (kbd "C-c h g") 'helm-do-grep)
 (global-set-key (kbd "C-c h C-c w") 'helm-wikipedia-suggest)
 (global-set-key (kbd "C-c h x") 'helm-register)
-
-(define-key 'help-command (kbd "C-f") 'helm-apropos)
-(define-key 'help-command (kbd "r") 'helm-info-emacs)
-(define-key 'help-command (kbd "C-l") 'helm-locate-library)
-
-;; use helm to list eshell history
-(add-hook 'eshell-mode-hook
-          #'(lambda ()
-              (define-key eshell-mode-map (kbd "M-l")  'helm-eshell-history)))
+(global-set-key (kbd "C-c h SPC") 'helm-all-mark-rings)
 
 ;;; Save current position to mark ring
 (add-hook 'helm-goto-line-before-hook 'helm-save-current-pos-to-mark-ring)
 
-;; show minibuffer history with Helm
-(define-key minibuffer-local-map (kbd "M-p") 'helm-minibuffer-history)
-(define-key minibuffer-local-map (kbd "M-n") 'helm-minibuffer-history)
+(defvar prelude-global-helm-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "M-x") 'helm-M-x)
+    (define-key map (kbd "M-y") 'helm-show-kill-ring)
+    (define-key map (kbd "C-x b") 'helm-mini)
+    (define-key map (kbd "C-x C-f") 'helm-find-files)
+    (define-key map (kbd "C-h C-f") 'helm-apropos)
+    (define-key map (kbd "C-h r") 'helm-info-emacs)
+    (define-key map (kbd "C-h C-l") 'helm-locate-library)
+    map)
+  "Keymap for Helm to replace standard Prelude's commands")
 
-(define-key global-map [remap find-tag] 'helm-etags-select)
-(define-key global-map [remap list-buffers] 'helm-buffers-list)
+(define-minor-mode prelude-global-helm-minor-mode
+  "Minor mode to replace Prelude default commands with \\{prelude-global-helm-map}"
+  :keymap prelude-global-helm-mode-map
+  (progn
+    ;; show minibuffer history with Helm
+    (define-key minibuffer-local-map (kbd "M-l") 'helm-minibuffer-history)
+    (define-key global-map [remap find-tag] 'helm-etags-select)
+    (define-key global-map [remap list-buffers] 'helm-mini)
 
-(define-key shell-mode-map (kbd "M-p") 'helm-comint-input-ring) ; shell history.
+    ;; shell history.
+    (define-key shell-mode-map (kbd "M-l") 'helm-comint-input-ring)
+
+    ;; use helm to list eshell history
+    (add-hook 'eshell-mode-hook
+              #'(lambda ()
+                  (define-key eshell-mode-map (kbd "M-l")  'helm-eshell-history)))))
+
+(define-globalized-minor-mode prelude-global-helm-global-mode prelude-global-helm-minor-mode prelude-global-helm-global-mode-on)
+
+(defun prelude-global-helm-global-mode-on ()
+  "Turn on `prelude-global-helm-minor-mode'"
+  (prelude-global-helm-minor-mode +1)
+  )
+
+(defun prelude-global-helm-global-mode-off ()
+  "Turn off `prelude-global-helm-minor-mode'"
+  (prelude-global-helm-minor-mode -1))
+
+(helm-mode 1)
+
+;; PACKAGE: helm-projectile
 
 (require 'helm-projectile)
 (setq projectile-completion-system 'helm)
 
 (push "Press <C-c p h> to navigate a project in Helm." prelude-tips)
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; PACKAGE: helm-descbinds                      ;;
-;;                                              ;;
-;; GROUP: Convenience -> Helm -> Helm Descbinds ;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; PACKAGE: helm-descbinds
 (require 'helm-descbinds)
 (helm-descbinds-mode)
 


### PR DESCRIPTION
Since some users prefer using default Prelude commands, a new global
mode is defined: prelude-global-helm-mode. When activate, Helm binds
some global key bindings to its own commands. When deactivate, Helm
removes the bindings and Prelude uses the default bindings.

@toctan I created the global mode.
