### PR TITLE
Enable prelude-global-helm-global-mode by default 

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,8 @@ Helm is setup according to this guide: [A Package in a league of its own: Helm](
 You can learn Helm usage and key bindings following the guide. <kbd>C-c h</kbd> is Prelude's default prefix key for Helm.
 If you don't remember any key binding, append <kbd>C-h</kbd> after <kbd>C-c h</kbd> for a list of key bindings in Helm.
 
-By default, Helm won't activate these global key bindings, so you can use Helm along with Ido and Prelude's default commands:
+If you love Helm and want to use Helm globally with enhanced `helm-find-files`, `helm-buffer-lists`..., you will have to also add `(require 'prelude-helm-everywhere)`.
+When `prelude-helm-everywhere` is activated, Helm enables these global key bindings:
 
 Key binding        | Description
 -------------------|----------------------------------------------
@@ -385,24 +386,26 @@ Key binding        | Description
 <kbd>M-y</kbd>     | Run [helm-show-kill-ring](http://tuhdo.github.io/helm-intro.html#sec-4), shows the content of `kill-ring`.
 <kbd>C-x b </kbd>  | Run [helm-mini](http://tuhdo.github.io/helm-intro.html#sec-5), an interactive version of `C-x b` with more features.
 <kbd>C-x C-f</kbd> | Run [helm-find-files](http://tuhdo.github.io/helm-intro.html#sec-6), an interactive version of `find-file` with more features.
-<kbd>C-h C-f </kbd>| Run [helm-apropos](http://tuhdo.github.io/helm-intro.html#sec-13), an interactive version of `apropos-command`.
+<kbd>C-h f </kbd>  | Run [helm-apropos](http://tuhdo.github.io/helm-intro.html#sec-13), an interactive version of `apropos-command`.
 <kbd>C-h r</kbd>   | Run [helm-info-emacs](http://tuhdo.github.io/helm-intro.html#sec-14), an interactive version of `info-emacs-manual`.
 <kbd>C-h C-l </kbd>| Run `helm-locate-library` that can search for locations of any file loaded into Emacs.
 
-This key binding won't be activated in `shell-mode`:
+This key binding is activated in `shell-mode`:
 
 Key Binding        | Description
 -------------------|----------------------------------------------
-<kbd>M-l</kbd>     | Run `helm-comint-input-ring` that shows `shell` history using Helm interface.
+<kbd>C-c C-l</kbd>     | Run `helm-comint-input-ring` that shows `shell` history using Helm interface.
 
-These key bindings won't be activated in `eshell-mode`:
+This key bindings is activated in `eshell-mode`:
 
 Key Binding        | Description
 -------------------|----------------------------------------------
-<kbd>M-l</kbd>     | Run `helm-eshell-history` that shows `eshell` history using Helm interface.
+<kbd>C-c C-l</kbd>     | Run `helm-eshell-history` that shows `eshell` history using Helm interface.
 
-You can use above key bindings by putting `(prelude-global-helm-global-mode +1)` right after `(require 'prelude-helm)`. If you enable
-these key bindings, you should not enable `prelude-ido`.
+If you prefer Ido in everywhere, you should not add `prelude-helm-everywhere`, so you can use Helm along with Ido and Prelude's default commands.
+
+You can always reactivate Helm with `(prelude-global-helm-global-mode-on)`.
+
 
 #### Key-chords
 

--- a/modules/prelude-helm-everywhere.el
+++ b/modules/prelude-helm-everywhere.el
@@ -1,0 +1,64 @@
+;;; prelude-helm-everywhere.el --- Enable Helm everywhere
+;;
+;; Copyright © 2014 Tu, Do Hoang
+;;
+;; Author: Tu, Do Hoang (tuhdo1710@gmail.com)
+;; URL: https://github.com/bbatsov/prelude
+;; Version: 1.0.0
+;; Keywords: convenience
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Enable Helm everywhere with global key bindings to replace common
+;; global bindings and `helm-mode' is activated to replace `completing-read'
+;; with `helm-completing-read-default', so users can use Helm with every prompt.
+
+;;; License:
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Code:
+(require 'prelude-helm)
+(require 'helm-descbinds)
+
+(global-set-key (kbd "M-x") 'helm-M-x)
+(global-set-key (kbd "M-y") 'helm-show-kill-ring)
+(global-set-key (kbd "C-x b") 'helm-mini)
+(global-set-key (kbd "C-x C-f") 'helm-find-files)
+(global-set-key (kbd "C-h f") 'helm-apropos)
+(global-set-key (kbd "C-h r") 'helm-info-emacs)
+(global-set-key (kbd "C-h C-l") 'helm-locate-library)
+(define-key prelude-mode-map (kbd "C-c f") 'helm-recentf)
+
+(define-key minibuffer-local-map (kbd "C-c C-l") 'helm-minibuffer-history)
+
+;; shell history.
+(define-key shell-mode-map (kbd "C-c C-l") 'helm-comint-input-ring)
+
+;; use helm to list eshell history
+(add-hook 'eshell-mode-hook
+          #'(lambda ()
+              (substitute-key-definition 'eshell-list-history 'helm-eshell-history eshell-mode-map)))
+
+(substitute-key-definition 'find-tag 'helm-etags-select global-map)
+(setq projectile-completion-system 'helm)
+(helm-descbinds-mode)
+(helm-mode 1)
+
+(provide 'prelude-helm-everywhere)
+;; prelude-helm-everywhere.el ends here.

--- a/modules/prelude-helm.el
+++ b/modules/prelude-helm.el
@@ -84,58 +84,9 @@
 ;;; Save current position to mark ring
 (add-hook 'helm-goto-line-before-hook 'helm-save-current-pos-to-mark-ring)
 
-(defvar prelude-global-helm-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "M-x") 'helm-M-x)
-    (define-key map (kbd "M-y") 'helm-show-kill-ring)
-    (define-key map (kbd "C-x b") 'helm-mini)
-    (define-key map (kbd "C-x C-f") 'helm-find-files)
-    (define-key map (kbd "C-h C-f") 'helm-apropos)
-    (define-key map (kbd "C-h r") 'helm-info-emacs)
-    (define-key map (kbd "C-h C-l") 'helm-locate-library)
-    map)
-  "Keymap for Helm to replace standard Prelude's commands")
-
-(define-minor-mode prelude-global-helm-minor-mode
-  "Minor mode to replace Prelude default commands with \\{prelude-global-helm-map}"
-  :keymap prelude-global-helm-mode-map
-  (progn
-    ;; show minibuffer history with Helm
-    (define-key minibuffer-local-map (kbd "M-l") 'helm-minibuffer-history)
-    (define-key global-map [remap find-tag] 'helm-etags-select)
-    (define-key global-map [remap list-buffers] 'helm-mini)
-
-    ;; shell history.
-    (define-key shell-mode-map (kbd "M-l") 'helm-comint-input-ring)
-
-    ;; use helm to list eshell history
-    (add-hook 'eshell-mode-hook
-              #'(lambda ()
-                  (define-key eshell-mode-map (kbd "M-l")  'helm-eshell-history)))))
-
-(define-globalized-minor-mode prelude-global-helm-global-mode prelude-global-helm-minor-mode prelude-global-helm-global-mode-on)
-
-(defun prelude-global-helm-global-mode-on ()
-  "Turn on `prelude-global-helm-minor-mode'"
-  (prelude-global-helm-minor-mode +1)
-  )
-
-(defun prelude-global-helm-global-mode-off ()
-  "Turn off `prelude-global-helm-minor-mode'"
-  (prelude-global-helm-minor-mode -1))
-
-(helm-mode 1)
-
 ;; PACKAGE: helm-projectile
-
 (require 'helm-projectile)
-(setq projectile-completion-system 'helm)
-
 (push "Press <C-c p h> to navigate a project in Helm." prelude-tips)
-
-;; PACKAGE: helm-descbinds
-(require 'helm-descbinds)
-(helm-descbinds-mode)
 
 (provide 'prelude-helm)
 

--- a/sample/prelude-modules.el
+++ b/sample/prelude-modules.el
@@ -4,6 +4,7 @@
 (require 'prelude-erc)
 (require 'prelude-ido) ;; Super charges Emacs completion for C-x C-f and more
 ;; (require 'prelude-helm) ;; Interface for narrowing and search
+;; (require 'prelude-helm-everywhere) ;; Enable Helm everywhere
 (require 'prelude-company)
 ;; (require 'prelude-key-chord) ;; Binds useful features to key combinations
 ;; (require 'prelude-mediawiki)


### PR DESCRIPTION
Only activates uses it when prelude-global-helm-global-mode is activated.

**Updated**:  Since Helm is another option to Ido, users who want to use it fully
should benefit from the default Prelude setup. If some users don't like, they can always disable global Helm mode according to the instructions in the homepage.
