### PR TITLE
Add Helm to the table of contents and move some packages to helm-everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ advised to always run Prelude with the latest Emacs - currently
 		- [Prelude Mode](#prelude-mode)
 		- [OSX modifier keys](#osx-modifier-keys)
 		- [Projectile](#projectile)
+		- [Helm](#helm)
 		- [Key-chords](#key-chords)
 			- [Disabling key-chords](#disabling-key-chords)
 - [Automatic package installation](#automatic-package-installation)

--- a/modules/prelude-helm-everywhere.el
+++ b/modules/prelude-helm-everywhere.el
@@ -34,7 +34,8 @@
 
 ;;; Code:
 (require 'prelude-helm)
-(require 'helm-descbinds)
+(prelude-require-packages '(helm-descbinds))
+(require 'helm-eshell)
 
 (global-set-key (kbd "M-x") 'helm-M-x)
 (global-set-key (kbd "M-y") 'helm-show-kill-ring)

--- a/modules/prelude-helm.el
+++ b/modules/prelude-helm.el
@@ -32,7 +32,7 @@
 
 ;;; Code:
 
-(prelude-require-packages '(helm helm-projectile helm-descbinds))
+(prelude-require-packages '(helm helm-projectile))
 
 (require 'helm)
 
@@ -42,7 +42,6 @@
 (setq helm-command-prefix-key "C-c h")
 
 (require 'helm-config)
-(require 'helm-eshell)
 (require 'helm-files)
 (require 'helm-grep)
 


### PR DESCRIPTION
I forgot to add Helm to table of contents. I also move `helm-descbinds` to `helm-everywhere`.
