### PR TITLE
Add anaconda-mode for python

### DIFF
--- a/modules/prelude-python.el
+++ b/modules/prelude-python.el
@@ -33,6 +33,12 @@
 
 ;;; Code:
 
+(prelude-require-package 'anaconda-mode)
+
+(when (boundp 'company-backends)
+  (prelude-require-package 'company-anaconda)
+  (add-to-list 'company-backends 'company-anaconda))
+
 (require 'prelude-programming)
 
 ;; Copy pasted from ruby-mode.el
@@ -77,6 +83,8 @@
 (defun prelude-python-mode-defaults ()
   "Defaults for Python programming."
   (subword-mode +1)
+  (anaconda-mode)
+  (eldoc-mode)
   (setq-local electric-layout-rules
               '((?: . (lambda ()
                         (if (python-info-statement-starts-block-p)
@@ -91,6 +99,7 @@
 
 (add-hook 'python-mode-hook (lambda ()
                               (run-hooks 'prelude-python-mode-hook)))
+
 (provide 'prelude-python)
 
 ;;; prelude-python.el ends here


### PR DESCRIPTION
`anaconda-mode` offers jump to method definition with <kbd>M-.</kbd>,
context-sensitive code completion via standard `completion-at-point` or
`company` and documentation lookup, it also works well with
`eldoc-mode`.
