### PR TITLE
Fix prelude-open-with

### DIFF
--- a/core/prelude-core.el
+++ b/core/prelude-core.el
@@ -42,18 +42,17 @@ When in dired mode, open file under the cursor.
 
 With a prefix ARG always prompt for command to use."
   (interactive "P")
-  (let ((current-file-name
-         (if (eq major-mode 'dired-mode)
-             (dired-get-file-for-visit)
-           buffer-file-name)))
-    (when current-file-name
-        (start-process "prelude-open-with-process"
-                       "*prelude-open-with-output*"
-                       (cond
-                        ((and (not arg) (eq system-type 'darwin)) "open")
-                        ((and (not arg) (member system-type '(gnu gnu/linux gnu/kfreebsd))) "xdg-open")
-                        (t (read-shell-command "Open current file with: ")))
-                       (shell-quote-argument current-file-name)))))
+  (let* ((current-file-name
+          (if (eq major-mode 'dired-mode)
+              (dired-get-file-for-visit)
+            buffer-file-name))
+         (open (pcase system-type
+                 (`darwin "open")
+                 ((pred (string-prefix-p "gnu")) "xdg-open")))
+         (program (if (or arg (not open))
+                      (read-shell-command "Open current file with: ")
+                    open)))
+    (start-process "prelude-open-with-process" nil program current-file-name)))
 
 (defun prelude-buffer-mode (buffer-or-name)
   "Retrieve the `major-mode' of BUFFER-OR-NAME."


### PR DESCRIPTION
Currently, `prelude-open-with` does not work with files whose name has a
space or non-ascii character in it. I guess `shell-quote-argument` is
not needed for `start-process`.

I also refactor the code a little bit, and since we dot not care about
the output of `open`, so I removed the buffer name passed to `start-process`
