### PR TITLE
Slim helm module

### DIFF
--- a/modules/prelude-helm.el
+++ b/modules/prelude-helm.el
@@ -11,7 +11,8 @@
 
 ;;; Commentary:
 
-;; Some config for Helm that follows this guide: http://tuhdo.github.io/helm-intro.html
+;; Some configuration for Helm following this guide:
+;; http://tuhdo.github.io/helm-intro.html
 
 ;;; License:
 
@@ -35,51 +36,37 @@
 (prelude-require-packages '(helm helm-projectile))
 
 (require 'helm)
+(require 'helm-grep)
+(require 'helm-files)
+(require 'helm-projectile)
 
-;; must set before helm-config, otherwise helm use default
-;; prefix "C-x c", which is inconvenient because you can
-;; accidentally pressed "C-x C-c"
-(setq helm-command-prefix-key "C-c h")
+;; The default "C-x c" is quite close to "C-x C-c", which quits Emacs.
+;; Note: this must be placed before require `helm-config'
+(defvar helm-command-prefix-key "C-c h")
 
 (require 'helm-config)
-(require 'helm-files)
-(require 'helm-grep)
-
-(define-key helm-map (kbd "<tab>") 'helm-execute-persistent-action) ; rebihnd tab to do persistent action
-(define-key helm-map (kbd "C-i") 'helm-execute-persistent-action) ; make TAB works in terminal
-(define-key helm-map (kbd "C-z") 'helm-select-action) ; list actions using C-z
-
-(define-key helm-grep-mode-map (kbd "<return>") 'helm-grep-mode-jump-other-window)
-(define-key helm-grep-mode-map (kbd "n") 'helm-grep-mode-jump-other-window-forward)
-(define-key helm-grep-mode-map (kbd "p") 'helm-grep-mode-jump-other-window-backward)
 
 (when (executable-find "curl")
-  (setq  helm-google-suggest-use-curl-p t))
+  (setq helm-google-suggest-use-curl-p t))
 
-(setq
- helm-scroll-amount 4 ; scroll 4 lines other window using M-<next>/M-<prior>
- helm-quick-update t ; do not display invisible candidates
- helm-ff-search-library-in-sexp t ; search for library in `require' and `declare-function' sexp.
- helm-split-window-default-side 'other ;; open helm buffer in another window
- helm-split-window-in-side-p t ;; open helm buffer inside current window, not occupy whole other window
- helm-buffers-favorite-modes (append helm-buffers-favorite-modes
-                                     '(picture-mode artist-mode))
- helm-candidate-number-limit 500 ; limit the number of displayed candidates
- helm-ff-file-name-history-use-recentf t
- helm-move-to-line-cycle-in-source t ; move to end or beginning of source
-                                        ; when reaching top or bottom of source.
- helm-buffers-fuzzy-matching t          ; fuzzy matching buffer names when non-nil
-                                        ; useful in helm-mini that lists buffers
- )
+;; See https://github.com/bbatsov/prelude/pull/670 for a detailed
+;; discussion of these options.
+(setq helm-quick-update                     t
+      helm-split-window-in-side-p           t
+      helm-buffers-fuzzy-matching           t
+      helm-move-to-line-cycle-in-source     t
+      helm-ff-search-library-in-sexp        t
+      helm-ff-file-name-history-use-recentf t)
 
-(global-set-key (kbd "C-c h o") 'helm-occur)
-(global-set-key (kbd "C-c h g") 'helm-do-grep)
-(global-set-key (kbd "C-c h C-c w") 'helm-wikipedia-suggest)
-(global-set-key (kbd "C-c h x") 'helm-register)
-(global-set-key (kbd "C-c h SPC") 'helm-all-mark-rings)
+(define-key helm-command-map (kbd "o")     'helm-occur)
+(define-key helm-command-map (kbd "g")     'helm-do-grep)
+(define-key helm-command-map (kbd "C-c w") 'helm-wikipedia-suggest)
+(define-key helm-command-map (kbd "SPC")   'helm-all-mark-rings)
 
-;; PACKAGE: helm-projectile
-(require 'helm-projectile)
+(define-key helm-grep-mode-map (kbd "RET") 'helm-grep-mode-jump-other-window)
+(define-key helm-grep-mode-map (kbd "n")   'helm-grep-mode-jump-other-window-forward)
+(define-key helm-grep-mode-map (kbd "p")   'helm-grep-mode-jump-other-window-backward)
+
 (push "Press <C-c p h> to navigate a project in Helm." prelude-tips)
 
 (provide 'prelude-helm)


### PR DESCRIPTION
- Keep only the basic configurations
- Code style, now the code are beautifully aligned
- use `defvar` instead `steq` in case the user want to override helm
  prefix in their preload personal config file.

See: https://github.com/bbatsov/prelude/pull/670
