### PR TITLE
Adjust Helm prefix key

### DIFF
--- a/modules/prelude-helm.el
+++ b/modules/prelude-helm.el
@@ -42,7 +42,7 @@
 
 ;; The default "C-x c" is quite close to "C-x C-c", which quits Emacs.
 ;; Note: this must be placed before require `helm-config'
-(defvar helm-command-prefix-key "C-c h")
+(setq helm-command-prefix-key "C-c h")
 
 (require 'helm-config)
 


### PR DESCRIPTION
helm-command-prefix-key is already defined with defcustom in
helm-config.el. It must be set before helm-config.el to take
effect. With current setting, "C-x c" is used instead of "C-c h" and it
conflicts with the guide on homepage. "C-x c" makes it easy to press
"C-x C-c" to close Emacs when pressing fast enough. "C-c h" is also
originally used for Helm in Prelude.

Currently, "C-c h" is disabled and none of the Helm commands is accessible, since helm-mode is not activated.
