### PR TITLE
Set Helm prefix key independent of Helm's packages

### DIFF
--- a/modules/prelude-helm.el
+++ b/modules/prelude-helm.el
@@ -60,6 +60,12 @@
       helm-ff-search-library-in-sexp        t
       helm-ff-file-name-history-use-recentf t)
 
+;; The default "C-x c" is quite close to "C-x C-c", which quits Emacs.
+;; Changed to "C-c h". Note: We must set "C-c h" globally, because we
+;; cannot change `helm-command-prefix-key' once `helm-config' is loaded.
+(global-set-key (kbd "C-c h") 'helm-command-prefix)
+(global-unset-key (kbd "C-x c"))
+
 (define-key helm-command-map (kbd "o")     'helm-occur)
 (define-key helm-command-map (kbd "g")     'helm-do-grep)
 (define-key helm-command-map (kbd "C-c w") 'helm-wikipedia-suggest)


### PR DESCRIPTION
Since `helm-command-prefix-key' must be loaded before`helm-config', we don't know if other Helm packages include `helm-config' and invalidate custom prefix key. This change makes prefix binding independent from any Helm package.
