### PR TITLE
Automatic highlighting with highlight-symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ Keybinding         | Description
 <kbd>C-c J</kbd> or <kbd>Super-></kbd>   | Switch between buffers with [`ace-jump-buffer`](https://github.com/waymondo/ace-jump-buffer)
 <kbd>C-=</kbd>     | Run `expand-region` (incremental text selection).
 <kbd>C-a</kbd>     | Run `prelude-move-beginning-of-line`. Read [this](http://emacsredux.com/blog/2013/05/22/smarter-navigation-to-the-beginning-of-a-line/) for details.
+<kbd>M-n</kbd>     | Jump to next highlighting symbol
+<kbd>M-p</kbd>     | Jump to previous highlighting symbol
 
 #### Prelude Mode
 

--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -382,6 +382,16 @@ indent yanked text (with prefix arg don't indent)."
 (global-set-key [remap kill-ring-save] 'easy-kill)
 (global-set-key [remap mark-sexp] 'easy-mark)
 
+;; highlight-symbol
+(require 'highlight-symbol)
+(highlight-symbol-nav-mode)
+(add-hook 'prog-mode-hook (lambda () (highlight-symbol-mode)))
+(add-hook 'org-mode-hook (lambda () (highlight-symbol-mode)))
+(setq highlight-symbol-idle-delay 0.2
+      highlight-symbol-on-navigation-p t)
+(global-set-key (kbd "M-n") 'highlight-symbol-next)
+(global-set-key (kbd "M-p") 'highlight-symbol-prev)
+
 ;; operate-on-number
 (require 'operate-on-number)
 (smartrep-define-key global-map "C-c ."

--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -64,6 +64,7 @@
     god-mode
     grizzl
     guru-mode
+    highlight-symbol
     ov
     projectile
     magit


### PR DESCRIPTION
This package enables automatic highlighting from highlight-symbol. It also provides a feature to navigate back and forth between highlighting symbols. Users can use M-n/M-p to move to next/previous symbols.