### PR TITLE
Fix python electric layout newline

### DIFF
--- a/modules/prelude-python.el
+++ b/modules/prelude-python.el
@@ -87,8 +87,9 @@
   (eldoc-mode)
   (setq-local electric-layout-rules
               '((?: . (lambda ()
-                        (if (python-info-statement-starts-block-p)
-                            'after)))))
+                        (and (zerop (first (syntax-ppss)))
+                             (python-info-statement-starts-block-p)
+                             'after)))))
   (when (fboundp #'python-imenu-create-flat-index)
     (setq-local imenu-create-index-function
                 #'python-imenu-create-flat-index))


### PR DESCRIPTION
Currently colon inside list slice or dict literal also starts a newline
if the colon is on the line of block start.
