### PR TITLE
A few improvements to the prelude-models.el

### DIFF
--- a/sample/prelude-modules.el
+++ b/sample/prelude-modules.el
@@ -1,7 +1,11 @@
+;;; prelude-modules --- List of available prelude modules
+;;;
+;;; Commentary:
 ;;; Uncomment the modules you'd like to use and restart Prelude afterwards
+;;;
+;;; Code:
 
-;; Emacs IRC client
-(require 'prelude-erc)
+(require 'prelude-erc) ;; Emacs IRC client
 (require 'prelude-ido) ;; Super charges Emacs completion for C-x C-f and more
 ;; (require 'prelude-helm) ;; Interface for narrowing and search
 ;; (require 'prelude-helm-everywhere) ;; Enable Helm everywhere
@@ -35,3 +39,6 @@
 ;; (require 'prelude-web) ;; Emacs mode for web templates
 (require 'prelude-xml)
 ;; (require 'prelude-yaml)
+
+(provide 'prelude-modules)
+;;; prelude-modules ends here


### PR DESCRIPTION
Move `prelude-erc` module description to the same line with the module to make it same with other modules.

Add small header and footer to meet Emacs guidelines.