### PR TITLE
don't re-enable menu-bar-mode in terminal

### DIFF
--- a/core/prelude-osx.el
+++ b/core/prelude-osx.el
@@ -64,7 +64,8 @@ Windows external keyboard from time to time."
 (define-key prelude-mode-map (kbd "C-c w") 'prelude-swap-meta-and-super)
 (define-key prelude-mode-map (kbd "s-/") 'hippie-expand)
 
-(menu-bar-mode +1)
+(when window-system 
+  (menu-bar-mode +1))
 
 (provide 'prelude-osx)
 ;;; prelude-osx.el ends here


### PR DESCRIPTION
When running on OSX in the terminal, prelude currently enables the menu-bar. This is a good thing when running the app, but in the shell it jars with the experience you're used to since it is normally not seen in the buffer area.

![1__emacsclient](https://cloud.githubusercontent.com/assets/4205/6780991/f607e348-d137-11e4-926c-022749088b00.png)

If I understand it correctly, it's not visible in any other system except terminal on OSX
