### PR TITLE
Custom theme via prelude-theme variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,10 +475,10 @@ line:
 (disable-theme 'zenburn)
 ```
 
-Or you can use another theme altogether by adding something like:
+Or you can use another theme altogether by adding something in `personal/preload` like:
 
 ```lisp
-(load-theme 'solarized-dark t)
+(setq prelude-theme 'solarized-dark)
 ```
 
 **P.S.** Solarized is not available by default - you'll have to

--- a/core/prelude-custom.el
+++ b/core/prelude-custom.el
@@ -93,6 +93,11 @@ Only modes that don't derive from `prog-mode' should be listed here."
   :type 'number
   :group 'prelude)
 
+(defcustom prelude-theme 'zenburn
+  "The default color theme, change this in your /personal/preload config."
+  :type 'symbol
+  :group 'prelude)
+
 (provide 'prelude-custom)
 
 ;;; prelude-custom.el ends here

--- a/core/prelude-ui.el
+++ b/core/prelude-ui.el
@@ -73,7 +73,7 @@
                                           "%b"))))
 
 ;; use zenburn as the default theme
-(load-theme 'zenburn t)
+(load-theme prelude-theme t)
 
 (provide 'prelude-ui)
 ;;; prelude-ui.el ends here

--- a/init.el
+++ b/init.el
@@ -99,8 +99,8 @@ by Prelude.")
 
 ;; the core stuff
 (require 'prelude-packages)
+(require 'prelude-custom)  ;; Needs to be loaded before core, editor and ui
 (require 'prelude-ui)
-(require 'prelude-custom)  ;; Needs to be loaded before core and editor
 (require 'prelude-core)
 (require 'prelude-mode)
 (require 'prelude-editor)


### PR DESCRIPTION
The problem with the current approach is that even if we call `disable-theme` explicitly, there still will be some leftovers with the previous loaded theme. In the case of zenburn for example, `smartrep-mode-line-active-bg` get set to "#383838", when you disable zenburn, it's still "#383838", when you load a light theme, it looks like hell.

![screen shot 2014-10-11 at 12 04 42 pm](https://cloud.githubusercontent.com/assets/2468952/4601395/bd9c7e04-50fb-11e4-92f6-497d526a59a5.png)

Now, the user can load their preferred theme via setting the variable in their preload personal configurations like:

``` el
(setq prelude-theme 'sanityinc-tomorrow-day)
```
