### PR TITLE
In helm-everywhere, bind "C-x C-m" to helm-M-x

### DIFF
--- a/modules/prelude-helm-everywhere.el
+++ b/modules/prelude-helm-everywhere.el
@@ -38,6 +38,7 @@
 (require 'helm-eshell)
 
 (global-set-key (kbd "M-x") 'helm-M-x)
+(global-set-key (kbd "C-x C-m") 'helm-M-x)
 (global-set-key (kbd "M-y") 'helm-show-kill-ring)
 (global-set-key (kbd "C-x b") 'helm-mini)
 (global-set-key (kbd "C-x C-f") 'helm-find-files)


### PR DESCRIPTION
Since Prelude binds "C-x C-m" to (smex), I think helm-everywhere should bind "C-x C-m" to (helm-M-x).
