### PR TITLE
Enable electric-layout-mode only with python-mode

### DIFF
--- a/modules/prelude-python.el
+++ b/modules/prelude-python.el
@@ -93,7 +93,8 @@
   (when (fboundp #'python-imenu-create-flat-index)
     (setq-local imenu-create-index-function
                 #'python-imenu-create-flat-index))
-  (electric-layout-mode +1)
+  (add-hook 'post-self-insert-hook
+            #'electric-layout-post-self-insert-function nil 'local)
   (add-hook 'after-save-hook 'prelude-python-mode-set-encoding nil 'local))
 
 (setq prelude-python-mode-hook 'prelude-python-mode-defaults)


### PR DESCRIPTION
The problem with electric-layout-mode is that it's global, it works
great with python-mode, but it may also cause some issues with other
major mode, see #694
