### PR TITLE
fix electric-layout-post-self-insert-function autoload

### DIFF
--- a/modules/prelude-python.el
+++ b/modules/prelude-python.el
@@ -39,6 +39,7 @@
   (prelude-require-package 'company-anaconda)
   (add-to-list 'company-backends 'company-anaconda))
 
+(require 'electric)
 (require 'prelude-programming)
 
 ;; Copy pasted from ruby-mode.el


### PR DESCRIPTION
`electric-layout-post-self-insert-function` is not autoloaded in Emacs
24.3, the current approach relies on the internal implementation of
`electric-layout-mode`, I certainly do not like it. But it seems like
there is no other way to achieve this. There should have been an
`electric-layout-loca-mode` just like `electric-indent-local-mode`.

@bbatsov What version of Emacs are you using right now? Do you test
prelude code on both versions? I'm on 24.4, I wonder if it's possible to
keep both version installed with homebrew.
