### PR TITLE
helm-every-where takes responsibility for buffers-list

### DIFF
--- a/modules/prelude-helm-everywhere.el
+++ b/modules/prelude-helm-everywhere.el
@@ -41,6 +41,7 @@
 (global-set-key (kbd "C-x C-m") 'helm-M-x)
 (global-set-key (kbd "M-y") 'helm-show-kill-ring)
 (global-set-key (kbd "C-x b") 'helm-mini)
+(global-set-key (kbd "C-x C-b") 'helm-buffers-list)
 (global-set-key (kbd "C-x C-f") 'helm-find-files)
 (global-set-key (kbd "C-h f") 'helm-apropos)
 (global-set-key (kbd "C-h r") 'helm-info-emacs)


### PR DESCRIPTION
If someone wanted to use `helm-everywhere`, would it not be a good idea if `helm-buffers-list` becomes associated with `C-x C-b` rather than using `ibuffer`?
