### PR TITLE
Disable helm-quick-update

### DIFF
--- a/modules/prelude-helm.el
+++ b/modules/prelude-helm.el
@@ -43,8 +43,7 @@
 
 ;; See https://github.com/bbatsov/prelude/pull/670 for a detailed
 ;; discussion of these options.
-(setq helm-quick-update                     t
-      helm-split-window-in-side-p           t
+(setq helm-split-window-in-side-p           t
       helm-buffers-fuzzy-matching           t
       helm-move-to-line-cycle-in-source     t
       helm-ff-search-library-in-sexp        t


### PR DESCRIPTION
It is not needed anymore since helm-candidate-number-limit is
small (less than several thousands). If this is the case, then there's
no difference between quick update and no quick update execution time.
Enabling helm-quick-update makes helm buffer flashing for every entered
character to retrieve new candidate list, which would annoy user.
