### PR TITLE
Added helper to open file with emacsclient using filename:line path

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,14 @@ alias vi='emacsclient -t'
 The last two aliases are helpful if you're used to editing files from
 the command line using `vi(m)`.
 
+Also you can open a file with cursor on choosen line:
+
+```bash
+emacsclient somefile:1234
+```
+
+This will open file 'somefile' and set cursor on line 1234.
+
 ## Getting to know Prelude
 
 Certainly the best way to understand how Prelude enhances the default

--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -397,6 +397,25 @@ indent yanked text (with prefix arg don't indent)."
     ("%" . apply-operation-to-number-at-point)
     ("'" . operate-on-number-at-point)))
 
+(defadvice server-visit-files (before parse-numbers-in-lines (files proc &optional nowait) activate)
+  "Open file with emacsclient with cursors positioned on requested line.
+Most of console-based utilities prints filename in format
+'filename:linenumber'.  So you may wish to open filename in that format.
+Just call:
+
+  emacsclient filename:linenumber
+
+and file 'filename' will be opened and cursor set on line 'linenumber'"
+  (ad-set-arg 0
+              (mapcar (lambda (fn)
+                        (let ((name (car fn)))
+                          (if (string-match "^\\(.*?\\):\\([0-9]+\\)\\(?::\\([0-9]+\\)\\)?$" name)
+                              (cons
+                               (match-string 1 name)
+                               (cons (string-to-number (match-string 2 name))
+                                     (string-to-number (or (match-string 3 name) ""))))
+                            fn))) files)))
+
 (provide 'prelude-editor)
 
 ;;; prelude-editor.el ends here


### PR DESCRIPTION
Most of console-based utilities prints filename in format
"filename:linenumber". So you may wish to open filename in that format.
This little 'advice' can do that. Just call:

emacsclient filename:linenumber

and cursor will be positioned on requested line.
