### PR TITLE
Fix condition for "if prelude alredy installed" in the installer

### DIFF
--- a/utils/installer.sh
+++ b/utils/installer.sh
@@ -149,7 +149,7 @@ then
 fi
 
 # If prelude is already installed
-if [ -d "$PRELUDE_INSTALL_DIR/core/prelude-core.el" ]
+if [ -f "$PRELUDE_INSTALL_DIR/core/prelude-core.el" ]
 then
     printf "\n\n$BRED"
     printf "You already have Prelude installed.$RESET\nYou'll need to remove $PRELUDE_INSTALL_DIR/prelude if you want to install Prelude again.\n"


### PR DESCRIPTION
We need check for existence of `core/prelude-core.el` and that this is file and is not directory