### PR TITLE
Don't create already existed directories

### DIFF
--- a/utils/installer.sh
+++ b/utils/installer.sh
@@ -15,8 +15,6 @@ install_prelude () {
 
 make_prelude_dirs () {
     printf " Making the required directories.\n$RESET"
-    mkdir -p "$PRELUDE_INSTALL_DIR/vendor" "$PRELUDE_INSTALL_DIR/personal"
-    mkdir -p "$PRELUDE_INSTALL_DIR/themes"
     mkdir -p "$PRELUDE_INSTALL_DIR/savefile"
 }
 


### PR DESCRIPTION
This directories (`personal`, `vendor`, `themes`) already exist in the repository and thus don't need to be created during installation process.