### PR TITLE
fix magit-filenotify error

### DIFF
--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -75,7 +75,7 @@
   "A list of packages to ensure are installed at launch.")
 
 (when (version<= "24.4" emacs-version)
-  (add-to-list 'prelude-packages '(magit-filenotify)))
+  (add-to-list 'prelude-packages 'magit-filenotify))
 
 (defun prelude-packages-installed-p ()
   "Check if all packages in `prelude-packages' are installed."


### PR DESCRIPTION
After the last update my emacs failed to load properly with error: Package `(magit-filenotify)-' is unavailable.

This fixed the issue for me.