### PR TITLE
Revert "[Fix #782] Added magit-filenotify"

### DIFF
--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -74,9 +74,6 @@
     zenburn-theme)
   "A list of packages to ensure are installed at launch.")
 
-(when (version<= "24.4" emacs-version)
-  (add-to-list 'prelude-packages 'magit-filenotify))
-
 (defun prelude-packages-installed-p ()
   "Check if all packages in `prelude-packages' are installed."
   (every #'package-installed-p prelude-packages))

--- a/modules/prelude-programming.el
+++ b/modules/prelude-programming.el
@@ -82,9 +82,6 @@ This functions should be added to the hooks of major modes for programming."
 (add-hook 'prog-mode-hook (lambda ()
                             (run-hooks 'prelude-prog-mode-hook)))
 
-(when (version<= "24.4" emacs-version)
-  (add-hook 'magit-status-mode-hook (lambda () (magit-filenotify-mode 1))))
-
 ;; enable on-the-fly syntax checking
 (if (fboundp 'global-flycheck-mode)
     (global-flycheck-mode +1)


### PR DESCRIPTION
Even in linux I felt it makes `magit-status` buffer hang on big repositories, so it's better to remove it completely

This reverts commit 003bbc4e0b5084a75be411d304869b1fbc87bcf1.
Fix #790
