### PR TITLE
Use K&R as default style

### DIFF
--- a/modules/prelude-c.el
+++ b/modules/prelude-c.el
@@ -35,7 +35,8 @@
 (require 'prelude-programming)
 
 (defun prelude-c-mode-common-defaults ()
-  (setq c-basic-offset 4)
+  (setq c-default-style "k&r"
+        c-basic-offset 4)
   (c-set-offset 'substatement-open 0))
 
 (setq prelude-c-mode-common-hook 'prelude-c-mode-common-defaults)


### PR DESCRIPTION
The default style for c-mode is gnu, which AFIK almost no one uses. Since this style is used for many different language we should have a better default. Good options are either k&r or linux, I chose k&r given that it's the more canonical style. 