### PR TITLE
`turn-on-eldoc-mode' is an obsolete command (as of 24.4)

### DIFF
--- a/modules/prelude-emacs-lisp.el
+++ b/modules/prelude-emacs-lisp.el
@@ -67,7 +67,7 @@ Start `ielm' if it's not already running."
 (defun prelude-emacs-lisp-mode-defaults ()
   "Sensible defaults for `emacs-lisp-mode'."
   (run-hooks 'prelude-lisp-coding-hook)
-  (turn-on-eldoc-mode)
+  (eldoc-mode +1)
   (prelude-recompile-elc-on-save)
   (rainbow-mode +1)
   (setq mode-name "EL")
@@ -84,7 +84,7 @@ Start `ielm' if it's not already running."
 (defun prelude-ielm-mode-defaults ()
   "Sensible defaults for `ielm'."
   (run-hooks 'prelude-interactive-lisp-coding-hook)
-  (turn-on-eldoc-mode))
+  (eldoc-mode +1))
 
 (setq prelude-ielm-mode-hook 'prelude-ielm-mode-defaults)
 


### PR DESCRIPTION
`turn-on-eldoc-mode' is an obsolete command (as of 24.4); use `eldoc-mode' instead.