### PR TITLE
Add possibily for a fallback-init.el file for old emacs versions

### DIFF
--- a/init.el
+++ b/init.el
@@ -39,7 +39,22 @@
 (message "Prelude is powering up... Be patient, Master %s!" current-user)
 
 (when (version< emacs-version "24.1")
-  (error "Prelude requires at least GNU Emacs 24.1, but you're running %s" emacs-version))
+  (let (fallbackfile versionmessage)
+    (setq fallbackfile (concat
+			(file-name-as-directory
+			 (concat (file-name-directory load-file-name)
+				 "fallback")) "init.el"))
+    (setq versionmessage (format "Prelude requires at least GNU Emacs 24.1, but you're running %s" emacs-version))
+    (if (file-readable-p fallbackfile)
+	(progn
+	  (message (concat versionmessage
+			   (format ". Executing fallback %s" fallbackfile)))
+	  (load fallbackfile)
+	  (error "Fallback to old init.el done"))
+      (error versionmessage)
+      )
+    )
+  )
 
 ;; Always load newest byte code
 (setq load-prefer-newer t)

--- a/init.el
+++ b/init.el
@@ -39,12 +39,14 @@
 (message "Prelude is powering up... Be patient, Master %s!" current-user)
 
 (when (version< emacs-version "24.1")
-  (let (fallbackfile versionmessage)
-    (setq fallbackfile (concat
-			(file-name-as-directory
-			 (concat (file-name-directory load-file-name)
-				 "fallback")) "init.el"))
-    (setq versionmessage (format "Prelude requires at least GNU Emacs 24.1, but you're running %s" emacs-version))
+  (let ((fallbackfile (concat
+                       (file-name-as-directory
+                        (concat (file-name-directory load-file-name)
+                                "fallback")) "init.el"))
+        (versionmessage
+         (format
+          "Prelude requires at least GNU Emacs 24.1, but you're running %s"
+          emacs-version)))
     (if (file-readable-p fallbackfile)
 	(progn
 	  (message (concat versionmessage

--- a/init.el
+++ b/init.el
@@ -38,25 +38,25 @@
 
 (message "Prelude is powering up... Be patient, Master %s!" current-user)
 
+;; Check for required version. If Emacs version is not high enough looking
+;; for a file 'fallback/init.el' and execute it as a fallback
 (when (version< emacs-version "24.1")
-  (let ((fallbackfile (concat
+  (let ((fallback-file (concat
                        (file-name-as-directory
                         (concat (file-name-directory load-file-name)
-                                "fallback")) "init.el"))
-        (versionmessage
+                                "fallback"))
+                       "init.el"))
+        (version-message
          (format
           "Prelude requires at least GNU Emacs 24.1, but you're running %s"
           emacs-version)))
-    (if (file-readable-p fallbackfile)
-	(progn
-	  (message (concat versionmessage
-			   (format ". Executing fallback %s" fallbackfile)))
-	  (load fallbackfile)
-	  (error "Fallback to old init.el done"))
-      (error versionmessage)
-      )
-    )
-  )
+    (if (file-readable-p fallback-file)
+        (progn
+          (message (concat version-message
+                           (format ". Executing fallback %s" fallback-file)))
+          (load fallback-file)
+          (error "Fallback to old init.el done"))
+      (error version-message))))
 
 ;; Always load newest byte code
 (setq load-prefer-newer t)


### PR DESCRIPTION
This change solves for me the following problem: I have a number of machines with different OS-versions which share a common /home. Some of these machines have emacs-versions that can't cope with the requirements of prelude but have well-working .emacs.d from the pre-prelude days.

What this patch does is: if the emacs-version is too old look for a file .emacs.d/fallback/init.el (fallback is the old .emacs.d or a symbolic link to it). If found: execute that. If not found only print the old error message (old behaviour)

That way I can use emacs on all machines without having to specify the initialization file to use and get the best possible environment
