### PR TITLE
Fix custom theme cannot be auto installed

### DIFF
--- a/core/prelude-ui.el
+++ b/core/prelude-ui.el
@@ -67,10 +67,6 @@
                                             (abbreviate-file-name (buffer-file-name))
                                           "%b"))))
 
-;; use zenburn as the default theme
-(when prelude-theme
-  (load-theme prelude-theme t))
-
 (require 'smart-mode-line)
 (setq sml/no-confirm-load-theme t)
 ;; delegate theming to the currently active theme

--- a/init.el
+++ b/init.el
@@ -126,6 +126,10 @@ by Prelude.")
   (message "Loading personal configuration files in %s..." prelude-personal-dir)
   (mapc 'load (directory-files prelude-personal-dir 't "^[^#].*el$")))
 
+;; use zenburn as the default theme
+(when prelude-theme
+  (load-theme prelude-theme t))
+
 (message "Prelude is ready to do thy bidding, Master %s!" current-user)
 
 (prelude-eval-after-init


### PR DESCRIPTION
According to README, I put `(setq prelude-theme 'solarized-dark)` in `personal/preload/override.el`. But it reports error as the package has not been installed.

I want to make the package auto installed while not modifying the Prelude code, so I suppose to move the `(load-theme prelude-theme t)` to `init.el` and after the `personal` configs. Then I can use `(prelude-require-package 'solarized-dark)` to auto install the theme package.