### PR TITLE
Minimal intrusion el file to enable fancy function and set glyphs

### DIFF
--- a/personal/clojure-fancy.el
+++ b/personal/clojure-fancy.el
@@ -1,0 +1,21 @@
+;; If, like me, you enjoy the emacs-live fancy function and set glyphs
+;;(eval-after-load 'clojure-mode
+;;  '(font-lock-add-keywords
+;;    'clojure-mode `(("(\\(fn\\)[\[[:space:]]"
+;;                     (0 (progn (compose-region (match-beginning 1)
+;;                                               (match-end 1) "λ")
+;;                               nil))))))
+
+;;(eval-after-load 'clojure-mode
+;;  '(font-lock-add-keywords
+;;    'clojure-mode `(("\\(#\\)("
+;;                     (0 (progn (compose-region (match-beginning 1)
+;;                                               (match-end 1) "ƒ")
+;;                               nil))))))
+
+;;(eval-after-load 'clojure-mode
+;;  '(font-lock-add-keywords
+;;    'clojure-mode `(("\\(#\\){"
+;;                     (0 (progn (compose-region (match-beginning 1)
+;;                                               (match-end 1) "∈")
+;;                               nil))))))


### PR DESCRIPTION
I happen to like the emacs-live version of glyphs for functions and sets. I've included an el file in personal to make adopting them easier. Simply remove the comment tags and go.