### PR TITLE
show keystrokes fast

### DIFF
--- a/core/prelude-ui.el
+++ b/core/prelude-ui.el
@@ -57,6 +57,9 @@
 (column-number-mode t)
 (size-indication-mode t)
 
+;; show keystrokes fast
+(setq echo-keystrokes 0.02)
+
 ;; enable y/n answers
 (fset 'yes-or-no-p 'y-or-n-p)
 


### PR DESCRIPTION
It's much friendlier for beginners to show them the keystrokes they are typing, and I find this invaluable in my own Emacs experience.