### PR TITLE
Improve slime repl

### DIFF
--- a/modules/prelude-common-lisp.el
+++ b/modules/prelude-common-lisp.el
@@ -60,8 +60,15 @@
   ;; default to SBCL on Linux and Windows
   (setq slime-default-lisp 'sbcl))
 
+;; Add fancy slime contribs
+(setq slime-contribs '(slime-fancy))
+
 (add-hook 'lisp-mode-hook (lambda () (run-hooks 'prelude-lisp-coding-hook)))
-(add-hook 'slime-repl-mode-hook (lambda () (run-hooks 'prelude-interactive-lisp-coding-hook)))
+;; rainbow-delimeters messes up colors in slime-repl, and doesn't seem to work
+;; anyway, so we won't use prelude-lisp-coding-defaults.
+(add-hook 'slime-repl-mode-hook (lambda ()
+                                  (smartparens-strict-mode +1)
+                                  (whitespace-mode -1)))
 
 (eval-after-load "slime"
   '(progn


### PR DESCRIPTION
This enables the slime-fancy contribs for slime, and no longer enables
rainbow-delimiters for the slime repl.

rainbow-delimiters doesn't seem to work with the slime-repl anyway, and
messes up all of the other colors.