### PR TITLE
Don't disable which-function-mode in Python

### DIFF
--- a/modules/prelude-python.el
+++ b/modules/prelude-python.el
@@ -89,7 +89,6 @@
   (subword-mode +1)
   (anaconda-mode 1)
   (eldoc-mode 1)
-  (which-function-mode -1)
   (setq-local electric-layout-rules
               '((?: . (lambda ()
                         (and (zerop (first (syntax-ppss)))


### PR DESCRIPTION
which-function-mode is a global minor mode.

This conflict with the enabling line in prelude-programming.el. If a
user don't want which-function-mode in Python, he can config the
variable 'which-func-modes.