### PR TITLE
banish  --no-check-certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ curl -L https://github.com/bbatsov/prelude/raw/master/utils/installer.sh | sh
 If you're using `wget` type:
 
 ```bash
-wget --no-check-certificate https://github.com/bbatsov/prelude/raw/master/utils/installer.sh -O - | sh
+wget https://github.com/bbatsov/prelude/raw/master/utils/installer.sh -O - | sh
 ```
 
 ### Manual


### PR DESCRIPTION
If curl is going to check the cert, wget should do the same