### PR TITLE
Fix quotes in LaTeX

### DIFF
--- a/modules/prelude-latex.el
+++ b/modules/prelude-latex.el
@@ -54,6 +54,8 @@
 ;; AUCTeX configuration
 (setq TeX-auto-save t)
 (setq TeX-parse-self t)
+(setq TeX-close-quote "")
+(setq TeX-open-quote "")
 
 (setq-default TeX-master nil)
 


### PR DESCRIPTION
With a default installation of Prelude and the `prelude-latex` package
enabled, when the user types `"` on a LaTeX document the following shows
up:

```
``|'
```

where the `|` is the point.

Note that the parenthesis are unbalanced, there's a missing single quote
`'` in the end.

The reason seems to be that both AUCTeX and SmartParens try to
autocomplete and they interact bad.

The solution is to disable AUCTeX autocompletion feature just for the
quotes and let SmartParens take over. It does the right thing by putting
the point on the right place and removing the closing quotes if the user
hits backspace.