### PR TITLE
isearch-occur is included in emacs core upstream

### DIFF
--- a/core/prelude-global-keybindings.el
+++ b/core/prelude-global-keybindings.el
@@ -89,12 +89,7 @@
 (global-set-key [remap kill-whole-line] 'prelude-kill-whole-line)
 
 ;; Activate occur easily inside isearch
-(define-key isearch-mode-map (kbd "C-o")
-  (lambda () (interactive)
-    (let ((case-fold-search isearch-case-fold-search))
-      (occur (if isearch-regexp
-                 isearch-string
-               (regexp-quote isearch-string))))))
+(define-key isearch-mode-map (kbd "C-o") 'isearch-occur)
 
 ;; use hippie-expand instead of dabbrev
 (global-set-key (kbd "M-/") 'hippie-expand)


### PR DESCRIPTION
Looks like it was originally incorporated in 2007,
https://github.com/emacs-mirror/emacs/commit/6e3057bbed906aaeae458b2e4ac5f81f3986edfa.

Technically this is bound to `M-s o` by default, but `C-o` is a nice shortcut.