### PR TITLE
Use ruby-mode for .cap files

### DIFF
--- a/modules/prelude-ruby.el
+++ b/modules/prelude-ruby.el
@@ -44,6 +44,7 @@
 (add-to-list 'auto-mode-alist '("Gemfile\\'" . ruby-mode))
 (add-to-list 'auto-mode-alist '("Guardfile\\'" . ruby-mode))
 (add-to-list 'auto-mode-alist '("Capfile\\'" . ruby-mode))
+(add-to-list 'auto-mode-alist '("\\.cap\\'" . ruby-mode))
 (add-to-list 'auto-mode-alist '("\\.thor\\'" . ruby-mode))
 (add-to-list 'auto-mode-alist '("\\.rabl\\'" . ruby-mode))
 (add-to-list 'auto-mode-alist '("Thorfile\\'" . ruby-mode))


### PR DESCRIPTION
Even though `Capistrano` suggest using `.rake` extension instead of `.cap` https://github.com/capistrano/capistrano/commit/7e41233d76fec0aca6877b62b876b7e2c9b85ec0

But, there are still lots of capistrano plugins insist on `.cap`, so let's add it.