### PR TITLE
Replace a couple of obsolete haskell-mode functions

### DIFF
--- a/modules/prelude-haskell.el
+++ b/modules/prelude-haskell.el
@@ -39,8 +39,8 @@
   '(progn
      (defun prelude-haskell-mode-defaults ()
        (subword-mode +1)
-       (turn-on-haskell-doc-mode)
-       (turn-on-haskell-indentation)
+       (haskell-doc-mode)
+       (haskell-indentation-mode)
        (interactive-haskell-mode +1))
 
      (setq prelude-haskell-mode-hook 'prelude-haskell-mode-defaults)


### PR DESCRIPTION
`turn-on-haskell-indentation` has been marked obsolete in favour of `haskell-indentation-mode`