### PR TITLE
Fix key binding for magit-blame

### DIFF
--- a/core/prelude-mode.el
+++ b/core/prelude-mode.el
@@ -74,7 +74,7 @@
     (define-key map (kbd "s-m m") 'magit-status)
     (define-key map (kbd "s-m l") 'magit-log)
     (define-key map (kbd "s-m f") 'magit-log-buffer-file)
-    (define-key map (kbd "s-m b") 'magit-blame)
+    (define-key map (kbd "s-m b") 'magit-blame-mode)
     (define-key map (kbd "s-o") 'prelude-smart-open-line-above)
 
     map)


### PR DESCRIPTION
magit-blame was changed to magit-blame-mode.