### PR TITLE
fix kill-region advice, close bbatsov/prelude#899

### DIFF
--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -197,7 +197,7 @@ The body of the advice is in BODY."
 (defadvice kill-region (before smart-cut activate compile)
   "When called interactively with no active region, kill a single line instead."
   (interactive
-   (if mark-active (list (region-beginning) (region-end))
+   (if mark-active (list (region-beginning) (region-end) rectangle-mark-mode)
      (list (line-beginning-position)
            (line-beginning-position 2)))))
 


### PR DESCRIPTION
The current `kill-region` advice does not play nice with
`rectangle-mark-mode`, see https://github.com/bbatsov/prelude/issues/899