### PR TITLE
[Fix #902] Fix kill-region advice function

### DIFF
--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -197,7 +197,7 @@ The body of the advice is in BODY."
 (defadvice kill-region (before smart-cut activate compile)
   "When called interactively with no active region, kill a single line instead."
   (interactive
-   (if mark-active (list (region-beginning) (region-end) rectangle-mark-mode)
+   (if mark-active (list (region-beginning) (region-end) (rectangle-mark-mode))
      (list (line-beginning-position)
            (line-beginning-position 2)))))
 


### PR DESCRIPTION
Prevent the advice function from causing errors when rectangle-mark-mode
is not activated.