### PR TITLE
[Fix #902] Fix kill-region advice

### DIFF
--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -194,6 +194,7 @@ The body of the advice is in BODY."
 
 ;; note - this should be after volatile-highlights is required
 ;; add the ability to cut the current line, without marking it
+(require 'rect)
 (defadvice kill-region (before smart-cut activate compile)
   "When called interactively with no active region, kill a single line instead."
   (interactive


### PR DESCRIPTION
The problem is that `rectangle-mark-mode` is autoloaded. I have something in my personal configuration that loads rect.el, so I didn't notice the problem when I tested the code. Sorry, my bad.
cc @mopsfelder @butala @vamega @FranklinChen