### PR TITLE
customize shell to run with prelude-visit-term-buffer

### DIFF
--- a/core/prelude-core.el
+++ b/core/prelude-core.el
@@ -67,7 +67,7 @@ This variable can be set via .dir-locals.el to provide multi-term support.")
   "Create or visit a terminal buffer."
   (interactive)
   (prelude-start-or-switch-to (lambda ()
-                                (ansi-term (getenv "SHELL") (concat prelude-term-buffer-name "-term")))
+                                (ansi-term prelude-shell (concat prelude-term-buffer-name "-term")))
                               (format "*%s-term*" prelude-term-buffer-name)))
 
 (defun prelude-search (query-url prompt)

--- a/core/prelude-custom.el
+++ b/core/prelude-custom.el
@@ -98,6 +98,11 @@ Only modes that don't derive from `prog-mode' should be listed here."
   :type 'symbol
   :group 'prelude)
 
+(defcustom prelude-shell (getenv "SHELL")
+  "The default shell to run with `prelude-visit-term-buffer'"
+  :type 'string
+  :group 'prelude)
+
 (provide 'prelude-custom)
 
 ;;; prelude-custom.el ends here


### PR DESCRIPTION
My default shell is zsh but it has some quirks when running from inside emacs, so I usually run ansi-term with /bin/bash. I thought it would be handy if shell passed to ansi-term in prelude-visit-term-buffer (which is bound to <kbd>C-c t</kbd>) would be customizable.