### PR TITLE
Add emoji support

### DIFF
--- a/core/prelude-osx.el
+++ b/core/prelude-osx.el
@@ -66,5 +66,8 @@ Windows external keyboard from time to time."
 
 (menu-bar-mode +1)
 
+;; Enable emoji, and stop the UI from freezing when trying to display them.
+(set-fontset-font t 'unicode "Apple Color Emoji" nil 'prepend)
+
 (provide 'prelude-osx)
 ;;; prelude-osx.el ends here


### PR DESCRIPTION
Enable emoji, and stop the UI from freezing when trying to display them.

Without this patch, emoji are not displayed:

<img width="388" alt="screen shot 2015-10-12 at 11 45 20 am" src="https://cloud.githubusercontent.com/assets/97816/10426727/1c8d733e-70e3-11e5-8f12-db8dfc3b9a1e.png">

Furthermore, trying to display an emoticon for the first time is very, very slow, because it just tries a bunch of fonts to see if they have an appropriate glyph (and fails). Worse, this is blocking IO, so the UI hangs while it's trying to do that. Very noticeable and annoying (>2s) even on a MBP with SSD!

After patch:

<img width="385" alt="screen shot 2015-10-12 at 1 16 21 pm" src="https://cloud.githubusercontent.com/assets/97816/10426753/754f7332-70e3-11e5-93f7-36a4e954a2bd.png">

:sparkles: :sparkling_heart: : :sparkles:

Thanks to @glyph for the actual code!