### PR TITLE
Fixed symbol definition void error regarding set-fontset-font in terminal environment   

### DIFF
--- a/core/prelude-osx.el
+++ b/core/prelude-osx.el
@@ -67,7 +67,9 @@ Windows external keyboard from time to time."
 (menu-bar-mode +1)
 
 ;; Enable emoji, and stop the UI from freezing when trying to display them.
-(set-fontset-font t 'unicode "Apple Color Emoji" nil 'prepend)
+;; unless it is on Terminal or iTerms
+(if window-system
+  (set-fontset-font t 'unicode "Apple Color Emoji" nil 'prepend))
 
 (provide 'prelude-osx)
 ;;; prelude-osx.el ends here


### PR DESCRIPTION
Fixed #919.