### PR TITLE
Replace deprecated utop-setup-ocaml-buffer function

### DIFF
--- a/modules/prelude-ocaml.el
+++ b/modules/prelude-ocaml.el
@@ -67,7 +67,7 @@
   ;; Enable Flycheck checker
   (flycheck-ocaml-setup))
 
-(add-hook 'tuareg-mode-hook #'utop-setup-ocaml-buffer)
+(add-hook 'tuareg-mode-hook #'utop-minor-mode)
 (add-hook 'tuareg-mode-hook #'merlin-mode)
 
 (add-hook 'tuareg-mode-hook (lambda ()


### PR DESCRIPTION
Thu Oct 29 13:01:54 GMT 2015

```
`utop-setup-ocaml-buffer' is deprecated, you need to
replace it by `utop-minor-mode'.

See https://github.com/diml/utop for configuration information.
```