### PR TITLE
Fix README for helm-projectile-find-other-file keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Keybinding         | Description
 <kbd>C-c p e</kbd> | Shows a list of recently visited project files.
 <kbd>C-c p s a</kbd> | Runs `ack` on the project. Requires the presence of `ack-and-a-half`.
 <kbd>C-c p s s</kbd> | Runs `ag` on the project. Requires the presence of `ag.el`.
-<kbd>C-c p a</kbd> | Runs `ack` on the project. Requires the presence of `ack-and-a-half`.
+<kbd>C-c p a</kbd> | Switch between files with the same name but different extensions.
 <kbd>C-c p c</kbd> | Runs a standard compilation command for your type of project.
 <kbd>C-c p P</kbd> | Runs a standard test command for your type of project.
 <kbd>C-c p z</kbd> | Adds the currently visited to the cache.


### PR DESCRIPTION
Keybinding <kbd>C-c p a</kbd> is bound to `helm-projectile-find-other-file`

`describe-key` agrees:
```
C-c p a runs the command helm-projectile-find-other-file, which is an
interactive autoloaded compiled Lisp function in `helm-projectile.el'.

It is bound to C-c p a, s-p a.

(helm-projectile-find-other-file &optional FLEX-MATCHING)

Switch between files with the same name but different extensions using Helm.
With FLEX-MATCHING, match any file that contains the base name of current file.
Other file extensions can be customized with the variable `projectile-other-file-alist'.
```