### PR TITLE
Don't invoke set-fontset-font if it is void

### DIFF
--- a/core/prelude-osx.el
+++ b/core/prelude-osx.el
@@ -67,7 +67,9 @@ Windows external keyboard from time to time."
 (menu-bar-mode +1)
 
 ;; Enable emoji, and stop the UI from freezing when trying to display them.
-(set-fontset-font t 'unicode "Apple Color Emoji" nil 'prepend)
+(if (fboundp 'set-fontset-font)
+    (set-fontset-font t 'unicode "Apple Color Emoji" nil 'prepend))
+
 
 (provide 'prelude-osx)
 ;;; prelude-osx.el ends here


### PR DESCRIPTION
Yesterday I noticed that `whitespace-mode` wasn’t working on my new machine. I tried reinstalling Emacs and Prelude with no luck, and gave up. :disappointed:  Later, I noticed an innocuous error message: `Symbol's function definition is void: set-fontset-font`. :confused:

I usually install Emacs like this: `brew install emacs` (no flags, no graphical support). On a blind guess, I tried re-installing like this: `brew install emacs --with-cocoa`. Lo and behold, it worked just fine! :tada: 

To prevent this from happening again, I’ve wrapped the reference to `set-fontset-font` in a crude if-expression (:see_no_evil:).

Forgive me for writing non-idiomatic emacslisp. I’m very open to any feedback as I have no idea whats going on.

Thanks!
Dylan