### PR TITLE
Fix non dotted pair element issue

### DIFF
--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -183,6 +183,8 @@ The body of the advice is in BODY."
   "Set buffer major mode according to `auto-mode-alist'."
   (let* ((name (buffer-name buffer))
          (mode (assoc-default name auto-mode-alist 'string-match)))
+    (when (and mode (consp mode))
+      (setq mode (car mode)))
     (with-current-buffer buffer (if mode (funcall mode)))))
 
 ;; highlight the current line


### PR DESCRIPTION
Every element of auto-mode-list are not dotted pair. For example
.gpg, .gz etc. assoc-default returns list for such buffer names and
funcall raises error because it is not function.

This is related to #968.
CC: @joonoro