### PR TITLE
Add a hook to magit that notifies diff-hl

### DIFF
--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -392,6 +392,7 @@ indent yanked text (with prefix arg don't indent)."
 ;; diff-hl
 (global-diff-hl-mode +1)
 (add-hook 'dired-mode-hook 'diff-hl-dired-mode)
+(add-hook 'magit-post-refresh-hook 'diff-hl-magit-post-refresh)
 
 ;; easy-kill
 (global-set-key [remap kill-ring-save] 'easy-kill)


### PR DESCRIPTION
diff-hl-mode was broken, it would not remove highlights even after a commit via magit.

As per the diff-hl-mode README

> If you're using a version before 2.4.0, it defines  magit-revert-buffer-hook (or magit-not-reverted-hook),  which we use.
  When using Magit 2.4 or newer, add this to your init script:
  (add-hook 'magit-post-refresh-hook 'diff-hl-magit-post-refresh)