### PR TITLE
Deletes prelude-top-join-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,6 @@ Keybinding         | Description
 <kbd>C-+</kbd>     | Increase font size(`text-scale-increase`).
 <kbd>C--</kbd>     | Decrease font size(`text-scale-decrease`).
 <kbd>C-x O</kbd>   | Go back to previous window (the inverse of `other-window` (`C-x o`)).
-<kbd>C-^</kbd>     | Join two lines into one(`prelude-top-join-line`).
 <kbd>C-x p</kbd>   | Start `proced` (manage processes from Emacs; works only in Linux).
 <kbd>C-x m</kbd>   | Start `eshell`.
 <kbd>C-x M-m</kbd> | Start your default shell.

--- a/core/prelude-global-keybindings.el
+++ b/core/prelude-global-keybindings.el
@@ -44,9 +44,6 @@
                                 (interactive)
                                 (other-window -1))) ;; back one
 
-;; Indentation help
-(global-set-key (kbd "C-^") 'prelude-top-join-line)
-
 ;; Start proced in a similar manner to dired
 (unless (eq system-type 'darwin)
     (global-set-key (kbd "C-x p") 'proced))


### PR DESCRIPTION
It is replaced with crux-top-join-line and s-j binding.