### PR TITLE
Replaced `scala-mode2` with `ensime` package.

### DIFF
--- a/modules/prelude-scala.el
+++ b/modules/prelude-scala.el
@@ -33,10 +33,10 @@
 ;;; Code:
 
 (require 'prelude-programming)
-(prelude-require-packages '(scala-mode2))
+(prelude-require-packages '(ensime))
 
 (defun prelude-scala-mode-defaults ()
-  (subword-mode +1))
+  (ensime-mode))
 
 (setq prelude-scala-mode-hook 'prelude-scala-mode-defaults)
 


### PR DESCRIPTION
* Since `scala-mode2` is not available on MELPA and is not activily developing.
* `ensime` package is accompanied with `scala-mode` and `sbt-mode`.
* Modified .gitignore file to ignore `target/` folder that is created by `sbt-mode`.