### PR TITLE
Use settings from .editorconfig file

### DIFF
--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -48,6 +48,10 @@
 ;; Newline at end of file
 (setq require-final-newline t)
 
+;; overwrite settings when .editorconfig file is present
+(require 'editorconfig)
+(editorconfig-mode 1)
+
 ;; delete the selection with a keypress
 (delete-selection-mode t)
 

--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -48,10 +48,6 @@
 ;; Newline at end of file
 (setq require-final-newline t)
 
-;; overwrite settings when .editorconfig file is present
-(require 'editorconfig)
-(editorconfig-mode 1)
-
 ;; delete the selection with a keypress
 (delete-selection-mode t)
 
@@ -437,6 +433,10 @@ and file 'filename' will be opened and cursor set on line 'linenumber'"
                                (cons (string-to-number (match-string 2 name))
                                      (string-to-number (or (match-string 3 name) ""))))
                             fn))) files)))
+
+;; use settings from .editorconfig file when present
+(require 'editorconfig)
+(editorconfig-mode 1)
 
 (provide 'prelude-editor)
 

--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -53,6 +53,7 @@
     diff-hl
     diminish
     easy-kill
+    editorconfig
     epl
     expand-region
     flycheck


### PR DESCRIPTION
[Editorconfig](http://editorconfig.org) is a nice way to provide cross editor settings like indentation of files or newlines at the end. Respecting these project specific settings is a good behavior for an editor and makes collaboration much easier.
