### PR TITLE
Call package-initialize in init.el

### DIFF
--- a/init.el
+++ b/init.el
@@ -32,6 +32,8 @@
 ;; Boston, MA 02110-1301, USA.
 
 ;;; Code:
+(package-initialize)
+
 (defvar current-user
       (getenv
        (if (equal system-type 'windows-nt) "USERNAME" "USER")))


### PR DESCRIPTION
This code is inserted by Package.el anyway each time Emacs is run,
resulting in local changes and prevents seamless rebasing.

Better add it as part of the default `init.el` file.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bbatsov/prelude/1024)

<!-- Reviewable:end -->
