### PR TITLE
pretzo -> prezto

### DIFF
--- a/modules/prelude-shell.el
+++ b/modules/prelude-shell.el
@@ -34,17 +34,17 @@
 
 (require 'sh-script)
 
-;; recognize pretzo files as zsh scripts
-(defvar prelude-pretzo-files '("zlogin" "zlogin" "zlogout" "zpretzorc" "zprofile" "zshenv" "zshrc"))
+;; recognize prezto files as zsh scripts
+(defvar prelude-prezto-files '("zlogin" "zlogin" "zlogout" "zpreztorc" "zprofile" "zshenv" "zshrc"))
 
 (mapc (lambda (file)
         (add-to-list 'auto-mode-alist `(,(format "\\%s\\'" file) . sh-mode)))
-      prelude-pretzo-files)
+      prelude-prezto-files)
 
 (add-hook 'sh-mode-hook
           (lambda ()
             (if (and buffer-file-name
-                     (member (file-name-nondirectory buffer-file-name) prelude-pretzo-files))
+                     (member (file-name-nondirectory buffer-file-name) prelude-prezto-files))
                 (sh-set-shell "zsh"))))
 
 (provide 'prelude-shell)


### PR DESCRIPTION
I am pretty sure the library being mentioned is called prezto, not pretzo. This misspelling meant that some configs weren't being properly included as zsh files in prelude-shell.el

(see: https://github.com/sorin-ionescu/prezto)