### PR TITLE
installer.sh renames .emacs if it exists

### DIFF
--- a/utils/installer.sh
+++ b/utils/installer.sh
@@ -179,6 +179,13 @@ then
     printf "$YELLOW WARNING:$RESET Prelude depends on emacs $RED 24$RESET !\n"
 fi
 
+if [ -f "$HOME/.emacs" ]
+then
+    ## If $HOME/.emacs exists, emacs ignores prelude's init.el, so remove it
+    printf " Backing up the existing $HOME/.emacs to $HOME/.emacs.pre-prelude\n"
+    mv $HOME/.emacs $HOME/.emacs.pre-prelude
+fi
+
 if [ -d "$PRELUDE_INSTALL_DIR" ] || [ -f "$PRELUDE_INSTALL_DIR" ]
 then
     # Existing file/directory found -> backup


### PR DESCRIPTION
If user has a $HOME/.emacs file, the prelude installer script
will install just fine, but when starting emacs, nothing will
take effect because emacs doesn't load .emacs.d/init.el if .emacs
exists. Because this is confusing for new users, the installer should
default to renaming this file to make emacs actually load prelude.

Sidenote: This is my first pull request. Please
let me know if I did something stupid.