### PR TITLE
Disable Flycheck warnings for `personal`

### DIFF
--- a/init.el
+++ b/init.el
@@ -93,7 +93,7 @@ by Prelude.")
 ;; preload the personal settings from `prelude-personal-preload-dir'
 (when (file-exists-p prelude-personal-preload-dir)
   (message "Loading personal configuration files in %s..." prelude-personal-preload-dir)
-  (mapc 'load (directory-files prelude-personal-preload-dir 't "^[^#].*el$")))
+  (mapc 'load (directory-files prelude-personal-preload-dir 't "^[^#\.].*el$")))
 
 (message "Loading Prelude's core...")
 
@@ -124,7 +124,7 @@ by Prelude.")
 ;; load the personal settings (this includes `custom-file')
 (when (file-exists-p prelude-personal-dir)
   (message "Loading personal configuration files in %s..." prelude-personal-dir)
-  (mapc 'load (directory-files prelude-personal-dir 't "^[^#].*el$")))
+  (mapc 'load (directory-files prelude-personal-dir 't "^[^#\.].*el$")))
 
 (message "Prelude is ready to do thy bidding, Master %s!" current-user)
 

--- a/personal/.dir-locals.el
+++ b/personal/.dir-locals.el
@@ -1,0 +1,5 @@
+;; This will make sure that nothing in your personal directory will be
+;; forced through the emacs-lisp-checkdoc flychecker. That's a great
+;; checker for real modules, but these are just config files, and you
+;; deserve not to get warnings all the time
+((emacs-lisp-mode . ((flycheck-disabled-checkers . (emacs-lisp-checkdoc)))))


### PR DESCRIPTION
- Modified the regex so prelude won't load any .el files that start with
  a `.`, spefically for `.dir-locals.el`. This file does not play nice
  with `load`
- Added a `personal/.dir-locals.el` to disable the flychecker
