### PR TITLE
Ignore emacs desktop files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ session*
 .cask
 tramp
 /var/pcache
+.emacs.desktop
+.emacs.desktop.lock


### PR DESCRIPTION
For users who enable [``desktop-save-mode``](https://www.gnu.org/software/emacs/manual/html_node/emacs/Saving-Emacs-Sessions.html), it is useful to have changes to the desktop files ignored by Git.