### PR TITLE
Update saveplace to work with emacs 25

### DIFF
--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -108,10 +108,12 @@
 (setq uniquify-ignore-buffers-re "^\\*") ; don't muck with special buffers
 
 ;; saveplace remembers your location in a file when saving files
-(require 'saveplace)
 (setq save-place-file (expand-file-name "saveplace" prelude-savefile-dir))
 ;; activate it for all buffers
-(setq-default save-place t)
+(if (< emacs-major-version 25)
+    (progn (require 'saveplace)
+           (setq-default save-place t))
+  (save-place-mode 1))
 
 ;; savehist keeps track of some history
 (require 'savehist)


### PR DESCRIPTION
Saveplace is broken in prelude with Emacs 25.  The configuration mechanism changed in Emacs 25.  See [Wiki](https://www.emacswiki.org/emacs/SavePlace).   This change fixes it for 25 and supports the old way for older emacsen.