### PR TITLE
Don't alter Ctrl-a binding in orgmode

### DIFF
--- a/modules/prelude-org.el
+++ b/modules/prelude-org.el
@@ -44,6 +44,7 @@
     (set-keymap-parent newmap oldmap)
     (define-key newmap (kbd "C-c +") nil)
     (define-key newmap (kbd "C-c -") nil)
+    (define-key newmap (kbd "C-a") nil)
     (make-local-variable 'minor-mode-overriding-map-alist)
     (push `(prelude-mode . ,newmap) minor-mode-overriding-map-alist))
 )


### PR DESCRIPTION
Hi!

In org-mode, `Ctrl-a` should be bound to `org-beginning-of-line`, which is fine because it is specially good with headlines.

However, since a few commits, Prelude binds `Ctrl-a` with `crux-move-beginning-of-line`, which is far less efficient in org-mode.

With this PR, Prelude won't mess with `Ctrl-a` binding in org-mode anymore.