### PR TITLE
Use http protocol instead of https for ELPA on Windows

### DIFF
--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -35,8 +35,12 @@
 (require 'cl)
 (require 'package)
 
-(add-to-list 'package-archives
-             '("melpa" . "https://melpa.org/packages/") t)
+(if (eq system-type 'windows-nt)
+    (add-to-list 'package-archives
+                 '("melpa" . "http://melpa.org/packages/") t)
+  (add-to-list 'package-archives
+               '("melpa" . "https://melpa.org/packages/") t)
+    )
 ;; set package-user-dir to be relative to Prelude install path
 (setq package-user-dir (expand-file-name "elpa" prelude-dir))
 (package-initialize)


### PR DESCRIPTION
On Windows, HTTPS is broken for ELPA. Instead, with this PR, Emacs will use HTTP on Windows (and HTTPS elsewhere).

Solves #1045