### PR TITLE
refined missing bundled example file warning

### DIFF
--- a/init.el
+++ b/init.el
@@ -123,7 +123,8 @@ by Prelude.")
 (if (file-exists-p prelude-modules-file)
     (load prelude-modules-file)
   (message "Missing modules file %s" prelude-modules-file)
-  (message "You can get started by copying the bundled example file"))
+  (message "You can get started by copying the bundled example file")
+  (message "in sample/prelude-modules.el"))
 
 ;; config changes made through the customize UI will be store here
 (setq custom-file (expand-file-name "custom.el" prelude-personal-dir))

--- a/init.el
+++ b/init.el
@@ -123,8 +123,7 @@ by Prelude.")
 (if (file-exists-p prelude-modules-file)
     (load prelude-modules-file)
   (message "Missing modules file %s" prelude-modules-file)
-  (message "You can get started by copying the bundled example file")
-  (message "in sample/prelude-modules.el"))
+  (message "You can get started by copying the bundled example file from sample/prelude-modules.el"))
 
 ;; config changes made through the customize UI will be store here
 (setq custom-file (expand-file-name "custom.el" prelude-personal-dir))


### PR DESCRIPTION
If you forget to copy the prelude-modules-file you get a warning. This is my suggested improvement. I have added the location of sample file.