### PR TITLE
Upgrade prelude-common-lisp.el

### DIFF
--- a/modules/prelude-common-lisp.el
+++ b/modules/prelude-common-lisp.el
@@ -62,7 +62,7 @@
   (setq slime-default-lisp 'sbcl))
 
 ;; Add fancy slime contribs
-(setq slime-contribs '(slime-fancy))
+(setq slime-contribs '(slime-fancy slime-cl-indent))
 
 (add-hook 'lisp-mode-hook (lambda () (run-hooks 'prelude-lisp-coding-hook)))
 ;; rainbow-delimeters messes up colors in slime-repl, and doesn't seem to work

--- a/modules/prelude-common-lisp.el
+++ b/modules/prelude-common-lisp.el
@@ -78,8 +78,6 @@
            slime-enable-evaluate-in-emacs t
            slime-autodoc-use-multiline-p t
            slime-auto-start 'always)
-     (set (make-local-variable 'tab-always-indent)
-          'complete)
      (define-key slime-mode-map (kbd "C-c C-s") 'slime-selector)))
 
 (provide 'prelude-common-lisp)

--- a/modules/prelude-common-lisp.el
+++ b/modules/prelude-common-lisp.el
@@ -78,8 +78,8 @@
            slime-enable-evaluate-in-emacs t
            slime-autodoc-use-multiline-p t
            slime-auto-start 'always)
-
-     (define-key slime-mode-map (kbd "TAB") 'slime-indent-and-complete-symbol)
+     (set (make-local-variable 'tab-always-indent)
+          'complete)
      (define-key slime-mode-map (kbd "C-c C-s") 'slime-selector)))
 
 (provide 'prelude-common-lisp)


### PR DESCRIPTION
1. Fix the following warning on each TAB stroke indent/completion:

> ‘slime-indent-and-complete-symbol’ is an obsolete command (as of 2015-10-18); 
   Set tab-always-indent to ’complete.

Similar modes and people had this problem before: [Use ` tab-always-indent`](https://github.com/greghendershott/racket-mode/issues/103).

2. Add slime-cl-indent to slime-contribs

This ensure that the right indent function will be used for Common Lisp idiomatic
indentation (which is different of Emacs Lisp).

Problems fixed with this: [Why does Emacs indent my Lisp LOOP construct weirdly?](https://emacs.stackexchange.com/questions/30788/why-does-emacs-indent-my-lisp-loop-construct-weirdly)