### PR TITLE
ido: remove ido-ubiquitous and add ido-completing-read+; fix #1096

### DIFF
--- a/modules/prelude-ido.el
+++ b/modules/prelude-ido.el
@@ -31,10 +31,10 @@
 ;; Boston, MA 02110-1301, USA.
 
 ;;; Code:
-(prelude-require-packages '(flx-ido ido-ubiquitous smex))
+(prelude-require-packages '(flx-ido ido-completing-read+ smex))
 
 (require 'ido)
-(require 'ido-ubiquitous)
+(require 'ido-completing-read+)
 (require 'flx-ido)
 
 (setq ido-enable-prefix nil

--- a/sample/prelude-pinned-packages.el
+++ b/sample/prelude-pinned-packages.el
@@ -74,7 +74,6 @@
         (helm-descbinds . "melpa-stable")
         (helm-projectile . "melpa-stable")
         (ido-completing-read+ . "melpa-stable")
-        (ido-ubiquitous . "melpa-stable")
         (imenu-anywhere . "melpa-stable")
         (inf-ruby . "melpa-stable")
         (js2-mode . "melpa-stable")


### PR DESCRIPTION
After version 4.0, ido-ubiquitous was merged into
ido-completing-read+. So ido-ubiquitous is no longer necessary.