### PR TITLE
Add the prelude-rust.el module

### DIFF
--- a/modules/prelude-rust.el
+++ b/modules/prelude-rust.el
@@ -48,15 +48,12 @@
   '(progn
      (add-hook 'rust-mode-hook 'racer-mode)
      (add-hook 'racer-mode-hook 'eldoc-mode)
-     (add-hook 'racer-mode-hook 'company-mode)
      (add-hook 'rust-mode-hook 'cargo-minor-mode)
      (add-hook 'rust-mode-hook 'flycheck-rust-setup)
      (add-hook 'flycheck-mode-hook 'flycheck-rust-setup)
 
      (defun prelude-rust-mode-defaults ()
-       (local-set-key (kbd "TAB") 'company-indent-or-complete-common)
-       (local-set-ket (kbd "C-c C-d") 'racer-describe)
-       (setq-local company-tooltip-align-annotations t)
+       (local-set-key (kbd "C-c C-d") 'racer-describe)
        ;; CamelCase aware editing operations
        (subword-mode +1))
 

--- a/modules/prelude-rust.el
+++ b/modules/prelude-rust.el
@@ -1,0 +1,66 @@
+;;; prelude-rust.el --- Emacs Prelude: Rust programming support.
+;;
+;; Authors: Doug MacEachern, Manoel Vilela
+;; Version: 1.0.1
+;; Keywords: convenience rust
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Prelude configuration for Rust
+
+;;; License:
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Code:
+
+(require 'prelude-programming)
+
+;; You may need installing the following packages on your systems:
+;; * rustc (Rust Compiler)
+;; * cargo (Rust Package Manager)
+;; * racer (Rust Completion Tool)
+
+(prelude-require-packages '(rust-mode
+                            racer
+                            flycheck-rust
+                            cargo))
+
+(eval-after-load 'rust-mode
+  '(progn
+     (add-hook 'rust-mode-hook 'racer-mode)
+     (add-hook 'racer-mode-hook 'eldoc-mode)
+     (add-hook 'racer-mode-hook 'company-mode)
+     (add-hook 'rust-mode-hook 'cargo-minor-mode)
+     (add-hook 'rust-mode-hook 'flycheck-rust-setup)
+     (add-hook 'flycheck-mode-hook 'flycheck-rust-setup)
+
+     (defun prelude-rust-mode-defaults ()
+       (local-set-key (kbd "TAB") 'company-indent-or-complete-common)
+       (setq-local company-tooltip-align-annotations t)
+       ;; CamelCase aware editing operations
+       (subword-mode +1))
+
+     (setq prelude-rust-mode-hook 'prelude-rust-mode-defaults)
+     (setq rust-format-on-save t)
+
+     (add-hook 'rust-mode-hook (lambda ()
+                               (run-hooks 'prelude-rust-mode-hook)))))
+
+(provide 'prelude-rust)
+;;; prelude-rust.el ends here

--- a/modules/prelude-rust.el
+++ b/modules/prelude-rust.el
@@ -31,7 +31,7 @@
 
 (require 'prelude-programming)
 
-;; You may need installing the following packages on your systems:
+;; You may need installing the following packages on your system:
 ;; * rustc (Rust Compiler)
 ;; * cargo (Rust Package Manager)
 ;; * racer (Rust Completion Tool)

--- a/modules/prelude-rust.el
+++ b/modules/prelude-rust.el
@@ -42,6 +42,8 @@
                             flycheck-rust
                             cargo))
 
+(setq rust-format-on-save t)
+
 (eval-after-load 'rust-mode
   '(progn
      (add-hook 'rust-mode-hook 'racer-mode)
@@ -58,7 +60,6 @@
        (subword-mode +1))
 
      (setq prelude-rust-mode-hook 'prelude-rust-mode-defaults)
-     (setq rust-format-on-save t)
 
      (add-hook 'rust-mode-hook (lambda ()
                                (run-hooks 'prelude-rust-mode-hook)))))

--- a/modules/prelude-rust.el
+++ b/modules/prelude-rust.el
@@ -35,6 +35,7 @@
 ;; * rustc (Rust Compiler)
 ;; * cargo (Rust Package Manager)
 ;; * racer (Rust Completion Tool)
+;; * rustfmt (Rust Tool for formatting code)
 
 (prelude-require-packages '(rust-mode
                             racer

--- a/modules/prelude-rust.el
+++ b/modules/prelude-rust.el
@@ -55,6 +55,7 @@
 
      (defun prelude-rust-mode-defaults ()
        (local-set-key (kbd "TAB") 'company-indent-or-complete-common)
+       (local-set-ket (kbd "C-c C-d") 'racer-describe)
        (setq-local company-tooltip-align-annotations t)
        ;; CamelCase aware editing operations
        (subword-mode +1))


### PR DESCRIPTION
The following module will use the packages:
* rust-mode (general utilities for rust development)
* flycheck-rust (syntax check)
* cargo (keybinding as minor-mode for using cargo package manager)
* racer (wrapper for the race code completion tool using company-mode)