### PR TITLE
[fix #1104] remove ido-completing-read+ from pinned packages

### DIFF
--- a/sample/prelude-pinned-packages.el
+++ b/sample/prelude-pinned-packages.el
@@ -73,7 +73,6 @@
         (helm-core . "melpa-stable")
         (helm-descbinds . "melpa-stable")
         (helm-projectile . "melpa-stable")
-        (ido-completing-read+ . "melpa-stable")
         (imenu-anywhere . "melpa-stable")
         (inf-ruby . "melpa-stable")
         (js2-mode . "melpa-stable")


### PR DESCRIPTION
Read the issue #1104 for the full description.