### PR TITLE
Ignore network-security.data file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ tramp
 /var/pcache
 .emacs.desktop
 .emacs.desktop.lock
+network-security.data


### PR DESCRIPTION
* This file is a temporary file used by Emacs Network Security Manager.
It keeps details about connections. Such file should be ignored 
and never committed.