### PR TITLE
Add commented out 'prelude-rust to sample

### DIFF
--- a/sample/prelude-modules.el
+++ b/sample/prelude-modules.el
@@ -29,6 +29,7 @@
 (require 'prelude-perl)
 ;; (require 'prelude-python)
 ;; (require 'prelude-ruby)
+;; (require 'prelude-rust)
 ;; (require 'prelude-scala)
 (require 'prelude-scheme)
 (require 'prelude-shell)


### PR DESCRIPTION
Commit https://github.com/bbatsov/prelude/commit/bfee53643c26c9a8623b7617ce5c46aea13d3bcd added a rust module, but the sample `prelude-modules` does not reference it yet.