### PR TITLE
.gitignore Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ tramp
 /var/pcache
 .emacs.desktop
 .emacs.desktop.lock
+personal/
+bookmarks
+anaconda-mode
+abbrev_defs


### PR DESCRIPTION
Updated .gitignore to exclude personal, bookmarks, and other ephemeral files and folders