### PR TITLE
Patch security vulnerability for emacs < 25.3

### DIFF
--- a/init.el
+++ b/init.el
@@ -135,6 +135,12 @@ by Prelude.")
 
 (message "Prelude is ready to do thy bidding, Master %s!" current-user)
 
+;; Patch security vulnerability in Emacs versions older than 25.3
+(when (version< emacs-version "25.3")
+  (eval-after-load "enriched"
+    '(defun enriched-decode-display-prop (start end &optional param)
+       (list start end))))
+
 (prelude-eval-after-init
  ;; greet the use with some useful tip
  (run-at-time 5 nil 'prelude-tip-of-the-day))


### PR DESCRIPTION
[Emacs 25.3](https://lists.gnu.org/archive/html/emacs-devel/2017-09/msg00211.html) was recently release to patch a security vulnerability. According to the patch notes, adding the following to your init file can patch this vulnerability for Emacs versions older than the 25.3 patch release.