### PR TITLE
Fix readme preload description

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,14 +526,11 @@ line:
 Or you can use another theme altogether by adding something in `personal/preload` like:
 
 ```lisp
-(prelude-require-package 'solarized-theme)
 (setq prelude-theme 'solarized-dark)
 ```
 
 **Note** [Solarized](https://github.com/bbatsov/zenburn-emacs) is not
-available by default - you'll have to install it from MELPA first,
-therefore the need for `prelude-require-package`.  Alternatively you
-can manually install the package like this - `M-x package-install RET
+available by default - you'll have to install it from MELPA first by `M-x package-install RET
 solarized-theme`.
 
 Finally, if you don't want any theme at all, you can add this to your

--- a/README.md
+++ b/README.md
@@ -526,12 +526,16 @@ line:
 Or you can use another theme altogether by adding something in `personal/preload` like:
 
 ```lisp
-(setq prelude-theme 'solarized-dark)
+(setq prelude-theme 'tango)
 ```
 
-**Note** [Solarized](https://github.com/bbatsov/zenburn-emacs) is not
-available by default - you'll have to install it from MELPA first by `M-x package-install RET
-solarized-theme`.
+**Note** To use a non-built-in theme, like [Solarized](https://github.com/bbatsov/zenburn-emacs),
+you'll have to install it from MELPA first by `M-x package-install RET solarized-theme`. Then add
+
+``` lisp
+(setq prelude-theme 'solarized-dark)
+```
+in `personal/preload`.
 
 Finally, if you don't want any theme at all, you can add this to your
 `personal/preload`:


### PR DESCRIPTION
`prelude-require-package` has not be defined during preloading. This
patch fixes readme description.

Fixes #1161