### PR TITLE
Stop Rust source files from being made executable

### DIFF
--- a/modules/prelude-rust.el
+++ b/modules/prelude-rust.el
@@ -53,6 +53,8 @@
 
   (defun prelude-rust-mode-defaults ()
     (local-set-key (kbd "C-c C-d") 'racer-describe)
+    ;; Prevent #! from chmodding rust files to be executable
+    (remove-hook 'after-save-hook 'executable-make-buffer-file-executable-if-script-p)
     ;; CamelCase aware editing operations
     (subword-mode +1))
 


### PR DESCRIPTION
Rust has an unfortunate syntax for setting attributes on a module file:

```rust
  #![...]
```

Since this is typically put at the top of the file, that makes the
shebang the first two characters, which makes the `after-save-hook`
function `executable-make-buffer-file-executable-if-script-p` function
change any such rust files executable.