### PR TITLE
Add ace-window ability to use home row key instead of number

### DIFF
--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -162,6 +162,9 @@
       (setq mode (car mode)))
     (with-current-buffer buffer (if mode (funcall mode)))))
 
+;; use home row instead of number
+(setq aw-keys '(?a ?s ?d ?f ?g ?h ?j ?k ?l))
+
 ;; highlight the current line
 (global-hl-line-mode +1)
 


### PR DESCRIPTION
Home row keys are faster to hit than numbers