### PR TITLE
[Fix #1171] exec-path-from-shell support on linux

### DIFF
--- a/core/prelude-linux.el
+++ b/core/prelude-linux.el
@@ -1,0 +1,43 @@
+;;; prelude-linux.el --- Emacs Prelude: linux specific settings.
+;;
+;; Copyright © 2011-2018 Bozhidar Batsov
+;;
+;; Author: Stanislav Arnaudov <stanislav_ts@avb.bg>
+;; URL: https://github.com/bbatsov/prelude
+;; Version: 1.0.0
+;; Keywords: convenience
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Some Linux specific stuff.
+
+;;; License:
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Code:
+
+;; On Linux Emacs doesn't use the shell PATH if it's not started from
+;; the shell. Let's fix that:
+(prelude-require-packages '(exec-path-from-shell))
+
+(require 'exec-path-from-shell)
+(exec-path-from-shell-initialize)
+
+(provide 'prelude-linux)
+;;; prelude-linux.el ends here

--- a/init.el
+++ b/init.el
@@ -117,6 +117,10 @@ by Prelude.")
 (when (eq system-type 'darwin)
   (require 'prelude-macos))
 
+;; Linux specific settings
+(when (eq system-type 'gnu/linux)
+  (require 'prelude-linux))
+
 (message "Loading Prelude's modules...")
 
 ;; the modules


### PR DESCRIPTION
As suggested by the title, this is a quick fix for #1171. I added a new core module - `prelude-linux.el` - and put the `exec-path-from-shell` there. I used the `prelude-macos.el` module as a template.  