### PR TITLE
Rust Language Server (RLS) support

### DIFF
--- a/modules/prelude-lsp.el
+++ b/modules/prelude-lsp.el
@@ -1,0 +1,63 @@
+;;; prelude-lsp.el --- lsp-mode setup
+;;
+;; Copyright © 2011-2018 Bozhidar Batsov
+;;
+;; Author: Bozhidar Batsov, Ben Alex
+;; URL: https://github.com/bbatsov/prelude
+;; Version: 1.0.0
+;; Keywords: convenience
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; lsp-mode config.
+
+;;; License:
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Code:
+
+(prelude-require-packages '(company-lsp
+                            lsp-mode
+                            lsp-ui))
+
+(require 'lsp-ui)
+(require 'company-lsp)
+(require 'lsp-imenu)
+
+(push 'company-lsp company-backends)
+(add-hook 'lsp-mode-hook 'lsp-ui-mode)
+(add-hook 'lsp-after-open-hook 'lsp-enable-imenu)
+
+(define-key lsp-ui-mode-map [remap xref-find-definitions] #'lsp-ui-peek-find-definitions)
+(define-key lsp-ui-mode-map [remap xref-find-references] #'lsp-ui-peek-find-references)
+(define-key lsp-ui-mode-map (kbd "C-c C-l .") 'lsp-ui-peek-find-definitions)
+(define-key lsp-ui-mode-map (kbd "C-c C-l ?") 'lsp-ui-peek-find-references)
+(define-key lsp-ui-mode-map (kbd "C-c C-l r") 'lsp-rename)
+(define-key lsp-ui-mode-map (kbd "C-c C-l x") 'lsp-restart-workspace)
+(define-key lsp-ui-mode-map (kbd "C-c C-l w") 'lsp-ui-peek-find-workspace-symbol)
+(define-key lsp-ui-mode-map (kbd "C-c C-l i") 'lsp-ui-peek-find-implementation)
+(define-key lsp-ui-mode-map (kbd "C-c C-l d") 'lsp-describe-thing-at-point)
+
+(setq lsp-ui-sideline-enable t)
+(setq lsp-ui-doc-enable t)
+(setq lsp-ui-peek-enable t)
+(setq lsp-ui-peek-always-show t)
+
+(provide 'prelude-lsp)
+;;; prelude-lsp.el ends here

--- a/modules/prelude-rust.el
+++ b/modules/prelude-rust.el
@@ -1,6 +1,6 @@
 ;;; prelude-rust.el --- Emacs Prelude: Rust programming support.
 ;;
-;; Authors: Doug MacEachern, Manoel Vilela
+;; Authors: Doug MacEachern, Manoel Vilela, Ben Alex
 ;; Version: 1.0.1
 ;; Keywords: convenience rust
 
@@ -36,23 +36,34 @@
 ;; * cargo (Rust Package Manager)
 ;; * racer (Rust Completion Tool)
 ;; * rustfmt (Rust Tool for formatting code)
+;; * rls (Rust Language Server, if the prelude-lsp feature is enabled)
 
 (prelude-require-packages '(rust-mode
-                            racer
-                            flycheck-rust
                             cargo))
 
+(if (featurep 'prelude-lsp)
+    (prelude-require-package 'lsp-rust)
+  (prelude-require-packages '(racer
+                              flycheck-rust)))
+
 (setq rust-format-on-save t)
+(setq lsp-rust-rls-command '("rustup" "run" "stable" "rls"))
 
 (with-eval-after-load 'rust-mode
-  (add-hook 'rust-mode-hook 'racer-mode)
-  (add-hook 'racer-mode-hook 'eldoc-mode)
   (add-hook 'rust-mode-hook 'cargo-minor-mode)
-  (add-hook 'rust-mode-hook 'flycheck-rust-setup)
-  (add-hook 'flycheck-mode-hook 'flycheck-rust-setup)
+
+  (if (featurep 'prelude-lsp)
+      (progn (require 'lsp-rust)
+             (add-hook 'rust-mode-hook #'lsp-rust-enable))
+    (add-hook 'rust-mode-hook 'racer-mode)
+    (add-hook 'racer-mode-hook 'eldoc-mode)
+    (add-hook 'rust-mode-hook 'flycheck-rust-setup)
+    (add-hook 'flycheck-mode-hook 'flycheck-rust-setup))
 
   (defun prelude-rust-mode-defaults ()
-    (local-set-key (kbd "C-c C-d") 'racer-describe)
+    (unless (featurep 'prelude-lsp)
+      (local-set-key (kbd "C-c C-d") 'racer-describe))
+
     ;; Prevent #! from chmodding rust files to be executable
     (remove-hook 'after-save-hook 'executable-make-buffer-file-executable-if-script-p)
     ;; CamelCase aware editing operations

--- a/sample/prelude-modules.el
+++ b/sample/prelude-modules.el
@@ -24,6 +24,7 @@
 (require 'prelude-js)
 ;; (require 'prelude-latex)
 (require 'prelude-lisp)
+(require 'prelude-lsp)
 ;; (require 'prelude-ocaml)
 (require 'prelude-org) ;; Org-mode helps you keep TODO lists, notes and more
 (require 'prelude-perl)


### PR DESCRIPTION
Adds Rust Language Server (RLS) support.

I separated out the Language Server Protocol (LSP) module so it can be used more easily by other languages. 

Given Rust's LSP integration is still early stage, the Rust module continues to use standard tools such as Racer and Flycheck by default. Only if the `prelude-lsp` module is enabled will RLS be used.