### PR TITLE
Move `prelude-modules.el` under `personal` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ custom.el
 places
 .smex-items
 savefile/
-/prelude-modules.el
 projectile-bookmarks.eld
 session*
 .cask

--- a/README.md
+++ b/README.md
@@ -104,8 +104,9 @@ Note that the installer will back up any existing `.emacs` file or
 you're doing a manual install make sure you don't have a `.emacs` file
 or back up your existing `.emacs.d` directory manually.
 
-Don't forget to adjust your `prelude-modules.el` file once the installation is done.
-By default most of the modules that ship with Prelude are not loaded.
+Don't forget to adjust your `prelude-modules.el` file in your personal directory
+once the installation is done. By default most of the modules
+that ship with Prelude are not loaded.
 
 ## Installing Emacs
 
@@ -222,8 +223,8 @@ By default most of the modules that ship with Prelude are not loaded. For more i
 You'll need to adjust your `prelude-modules.el` file once the
 installation is done. If you are doing a manual install then you first
 need to copy the `prelude-modules.el` available in the sample
-directory to the root of `path/to/prelude/installation` and then
-adjust that one.
+directory to the `personal` directory under `path/to/prelude/installation`
+and then adjust that one.
 
 After you've uncommented a module you should either restart Emacs or evaluate the module
 `require` expression with <kbd>C-x C-e</kbd>.
@@ -553,7 +554,7 @@ lexicographical order.  The overall loading precedence is:
 
 1.  `personal/preload/*`
 2.  `core/`
-3.  `prelude-modules.el`
+3.  `personal/prelude-modules.el` (or deprecated `prelude-modules.el`)
 4.  `personal/*`
 
 #### Personalization Example

--- a/init.el
+++ b/init.el
@@ -69,8 +69,13 @@ by Prelude.")
   "This directory houses packages that are not yet available in ELPA (or MELPA).")
 (defvar prelude-savefile-dir (expand-file-name "savefile" prelude-dir)
   "This folder stores all the automatically generated save/history-files.")
-(defvar prelude-modules-file (expand-file-name "prelude-modules.el" prelude-dir)
-  "This files contains a list of modules that will be loaded by Prelude.")
+(defvar prelude-modules-file (expand-file-name "prelude-modules.el" prelude-personal-dir)
+  "This file contains a list of modules that will be loaded by Prelude.")
+(defvar prelude-deprecated-modules-file
+  (expand-file-name "prelude-modules.el" prelude-dir)
+  (format "This file may contain a list of Prelude modules.
+
+This is DEPRECATED, use %s instead." prelude-modules-file))
 
 (unless (file-exists-p prelude-savefile-dir)
   (make-directory prelude-savefile-dir))
@@ -125,9 +130,18 @@ by Prelude.")
 
 ;; the modules
 (if (file-exists-p prelude-modules-file)
-    (load prelude-modules-file)
-  (message "Missing modules file %s" prelude-modules-file)
-  (message "You can get started by copying the bundled example file from sample/prelude-modules.el"))
+    (progn
+      (load prelude-modules-file)
+      (if (file-exists-p prelude-deprecated-modules-file)
+          (message "Loading new modules configuration, ignoring DEPRECATED prelude-module.el")))
+  (if (file-exists-p prelude-deprecated-modules-file)
+      (progn
+        (load prelude-deprecated-modules-file)
+        (message (format "The use of %s is DEPRECATED! Use %s instead!"
+                         prelude-deprecated-modules-file
+                         prelude-modules-file)))
+    (message "Missing modules file %s" prelude-modules-file)
+    (message "You can get started by copying the bundled example file from sample/prelude-modules.el")))
 
 ;; config changes made through the customize UI will be stored here
 (setq custom-file (expand-file-name "custom.el" prelude-personal-dir))
@@ -135,7 +149,7 @@ by Prelude.")
 ;; load the personal settings (this includes `custom-file')
 (when (file-exists-p prelude-personal-dir)
   (message "Loading personal configuration files in %s..." prelude-personal-dir)
-  (mapc 'load (directory-files prelude-personal-dir 't "^[^#\.].*el$")))
+  (mapc 'load (directory-files prelude-personal-dir 't "^[^#\.].*el$|^prelude-modules\.el$")))
 
 (message "Prelude is ready to do thy bidding, Master %s!" current-user)
 

--- a/utils/installer.sh
+++ b/utils/installer.sh
@@ -202,7 +202,7 @@ then
     make_prelude_dirs
     # Reinstate files that weren't replaced
     tar --skip-old-files -xf "$PRELUDE_INSTALL_DIR_ORIG.pre-prelude.tar" "$PRELUDE_INSTALL_DIR" > /dev/null 2>&1
-    [ -n "$PRELUDE_INTO" ] && cp "$PRELUDE_INSTALL_DIR/sample/prelude-modules.el" "$PRELUDE_INSTALL_DIR"
+    [ -n "$PRELUDE_INTO" ] && cp "$PRELUDE_INSTALL_DIR/sample/prelude-modules.el" "$PRELUDE_INSTALL_DIR/personal"
 elif [ -e "$PRELUDE_INSTALL_DIR" ]
 then
     # File exist but not a regular file or directory
@@ -215,7 +215,7 @@ else
     # Nothing yet so just install prelude
     install_prelude
     make_prelude_dirs
-    cp "$PRELUDE_INSTALL_DIR/sample/prelude-modules.el" "$PRELUDE_INSTALL_DIR"
+    cp "$PRELUDE_INSTALL_DIR/sample/prelude-modules.el" "$PRELUDE_INSTALL_DIR/personal"
 fi
 
 if [ -z "$PRELUDE_SKIP_BC" ];


### PR DESCRIPTION
Prelude modules are required by the definition file `prelude-modules.el`.
This file should be part of personal configuration.

Therefore:

- implemented loading of `personal/prelude-modules.el` in favour of
  loading `prelude-modules.el`;
- added a check for presence of both old and new files;
- adjusted documentation;
- adjusted the installer.

Closes #1206.