### PR TITLE
Fix Rust LSP

### DIFF
--- a/modules/prelude-lsp.el
+++ b/modules/prelude-lsp.el
@@ -37,12 +37,7 @@
                             lsp-ui))
 
 (require 'lsp-ui)
-(require 'company-lsp)
 (require 'lsp-ui-imenu)
-
-(push 'company-lsp company-backends)
-(add-hook 'lsp-mode-hook 'lsp-ui-mode)
-(add-hook 'lsp-after-open-hook 'lsp-ui-enable-imenu)
 
 (define-key lsp-ui-mode-map [remap xref-find-definitions] #'lsp-ui-peek-find-definitions)
 (define-key lsp-ui-mode-map [remap xref-find-references] #'lsp-ui-peek-find-references)

--- a/modules/prelude-rust.el
+++ b/modules/prelude-rust.el
@@ -39,26 +39,22 @@
 ;; * rls (Rust Language Server, if the prelude-lsp feature is enabled)
 
 (prelude-require-packages '(rust-mode
-                            cargo))
+                            cargo
+                            flycheck-rust))
 
-(if (featurep 'prelude-lsp)
-    (prelude-require-package 'lsp-rust)
-  (prelude-require-packages '(racer
-                              flycheck-rust)))
+(unless (featurep 'prelude-lsp)
+  (prelude-require-packages '(racer)))
 
 (setq rust-format-on-save t)
-(setq lsp-rust-rls-command '("rustup" "run" "stable" "rls"))
 
 (with-eval-after-load 'rust-mode
   (add-hook 'rust-mode-hook 'cargo-minor-mode)
+  (add-hook 'flycheck-mode-hook 'flycheck-rust-setup)
 
   (if (featurep 'prelude-lsp)
-      (progn (require 'lsp-rust)
-             (add-hook 'rust-mode-hook #'lsp-rust-enable))
+      (add-hook 'rust-mode-hook 'lsp)
     (add-hook 'rust-mode-hook 'racer-mode)
-    (add-hook 'racer-mode-hook 'eldoc-mode)
-    (add-hook 'rust-mode-hook 'flycheck-rust-setup)
-    (add-hook 'flycheck-mode-hook 'flycheck-rust-setup))
+    (add-hook 'racer-mode-hook 'eldoc-mode))
 
   (defun prelude-rust-mode-defaults ()
     (unless (featurep 'prelude-lsp)


### PR DESCRIPTION
* Removed lsp-rust (RLS is built into lsp-mode now)
* Fixed setting up flycheck mode in rust mode
* Fixed LSP initialization due to deprecation
* LSP-mode now self configures company and ui-mode