### PR TITLE
package initialise on emacs 27 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ prelude-cheatsheet.el
 prelude-cheatsheet.aux
 prelude-cheatsheet.log
 package-quickstart.el
+package-quickstart.el

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ network-security.data
 prelude-cheatsheet.el
 prelude-cheatsheet.aux
 prelude-cheatsheet.log
+package-quickstart.el

--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -50,13 +50,11 @@
 
 ;; set package-user-dir to be relative to Prelude install path
 (setq package-user-dir (expand-file-name "elpa" prelude-dir))
-;; Package initialize in emacs 27
-(if (or (version< emacs-version "27")
-        (progn
-          (not package--initialized)
-          ;; Used in emacs 27 to speed up initial package loading
-          (setq package-quickstart t)))
-    (package-initialize))
+(when (or (version< emacs-version "27")
+          (progn
+           (not package--initialized)
+           (setq package-quickstart t)))
+  (package-initialize))
 (defvar prelude-packages
   '(ace-window
     avy

--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -50,8 +50,13 @@
 
 ;; set package-user-dir to be relative to Prelude install path
 (setq package-user-dir (expand-file-name "elpa" prelude-dir))
-(package-initialize)
-
+;; Package initialize in emacs 27
+(if (or (version< emacs-version "27")
+        (progn
+          (not package--initialized)
+          ;; Used in emacs 27 to speed up initial package loading
+          (setq package-quickstart t)))
+    (package-initialize))
 (defvar prelude-packages
   '(ace-window
     avy

--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -50,13 +50,8 @@
 
 ;; set package-user-dir to be relative to Prelude install path
 (setq package-user-dir (expand-file-name "elpa" prelude-dir))
-;; Package initialize in emacs 27
-(if (or (version< emacs-version "27")
-        (progn
-          (not package--initialized)
-          ;; Used in emacs 27 to speed up initial package loading
-          (setq package-quickstart t)))
-    (package-initialize))
+(package-initialize)
+
 (defvar prelude-packages
   '(ace-window
     avy


### PR DESCRIPTION
To inhibit this annoying message `Unnecessary call to ‘package-initialize’ in init file `, if ever shows up and also `package-quickstart` is set to true, to start up initial package loading,
if it's ever needed