### PR TITLE
Replaces the use of `magit-log-popup' with `magit-log' for evil-mode.

### DIFF
--- a/modules/prelude-evil.el
+++ b/modules/prelude-evil.el
@@ -114,10 +114,10 @@
 (evil-add-hjkl-bindings magit-commit-mode-map 'emacs)
 (evil-add-hjkl-bindings magit-branch-manager-mode-map 'emacs
   "K" 'magit-discard
-  "L" 'magit-log-popup)
+  "L" 'magit-log)
 (evil-add-hjkl-bindings magit-status-mode-map 'emacs
   "K" 'magit-discard
-  "l" 'magit-log-popup
+  "l" 'magit-log
   "h" 'magit-diff-toggle-refine-hunk)
 
 (setq evil-shift-width 2)


### PR DESCRIPTION
This is also mentioned in bbatsov/prelude#1226 and originates from
magit/magit#3695.