### PR TITLE
Replace usage of `magit-dispatch-popup` with `magit-dispatch`

### DIFF
--- a/core/prelude-global-keybindings.el
+++ b/core/prelude-global-keybindings.el
@@ -103,7 +103,7 @@
 (global-set-key (kbd "<f12>") 'menu-bar-mode)
 
 (global-set-key (kbd "C-x g") 'magit-status)
-(global-set-key (kbd "C-x M-g") 'magit-dispatch-popup)
+(global-set-key (kbd "C-x M-g") 'magit-dispatch)
 
 (global-set-key (kbd "C-=") 'er/expand-region)
 

--- a/doc/prelude-cheatsheet.tex
+++ b/doc/prelude-cheatsheet.tex
@@ -77,7 +77,7 @@
   \item[<f11>] prelude-fullscreen
   \item[<f12>] menu-bar-mode
   \item[C-x g] magit-status
-  \item[C-x M-g] magit-dispatch-popup
+  \item[C-x M-g] magit-dispatch
   \end{keylist}
 
   \subsection{prelude}


### PR DESCRIPTION
`magit-dispatch-popup` is an obsolete command (as of Magit 2.91.0)