### PR TITLE
Extend rust module keybindings

### DIFF
--- a/modules/prelude-rust.el
+++ b/modules/prelude-rust.el
@@ -58,7 +58,9 @@
 
   (defun prelude-rust-mode-defaults ()
     (unless (featurep 'prelude-lsp)
-      (local-set-key (kbd "C-c C-d") 'racer-describe))
+      (local-set-key (kbd "C-c C-d") 'racer-describe)
+      (local-set-key (kbd "C-c .") 'racer-find-definition)
+      (local-set-key (kbd "C-c ,") 'pop-tag-mark))
 
     ;; Prevent #! from chmodding rust files to be executable
     (remove-hook 'after-save-hook 'executable-make-buffer-file-executable-if-script-p)


### PR DESCRIPTION
Hello,

I'm heavily using `racer` to find a function definition (`racer-find-definition`), so I thought I could share my bindings to push/pop function into definitions. The bindings are those I'm familiar with the Prelude python module, so I think that other can adapt quickly?

By the way, I use `racer-describe`, too, but with another binding:
```
(local-set-key (kbd "C-c C-?") 'racer-describe)
```
again, from the prelude python module. Don't know if it would make sense to change it also in the Rust module, it's your call.

thanks for your thoughts on this :)