### PR TITLE
Add Handlebars .hbs parsing using web-mode

### DIFF
--- a/modules/prelude-web.el
+++ b/modules/prelude-web.el
@@ -39,6 +39,7 @@
 (add-to-list 'auto-mode-alist '("\\.phtml\\'" . web-mode))
 (add-to-list 'auto-mode-alist '("\\.tpl\\.php\\'" . web-mode))
 (add-to-list 'auto-mode-alist '("\\.tpl\\'" . web-mode))
+(add-to-list 'auto-mode-alist '("\\.hbs\\'" . web-mode))
 (add-to-list 'auto-mode-alist '("\\.blade\\.php\\'" . web-mode))
 (add-to-list 'auto-mode-alist '("\\.jsp\\'" . web-mode))
 (add-to-list 'auto-mode-alist '("\\.as[cp]x\\'" . web-mode))


### PR DESCRIPTION
web-mode.el already supports .hbs (handlebars) files. This extension is used for general handlebars files and is used in ember.js projects. Added .hbs to the web-mode.el file extension list.