### PR TITLE
Include the Go in list of modules index

### DIFF
--- a/doc/modules/index.md
+++ b/doc/modules/index.md
@@ -58,6 +58,7 @@ To use a module you simple have to require it. No new concepts. No magic.
 - [ERC](erc.md)
 - Erlang
 - Elixir
+- Go
 - Haskell
 - JavaScript
 - LaTeX


### PR DESCRIPTION
Prelude has support for the Go Programming Language, yet Go is not included in the list.  This commit rectifies the omission.

https://github.com/bbatsov/prelude/blob/master/modules/prelude-go.el