### PR TITLE
Add a prelude-smartparens-strict customization.

### DIFF
--- a/core/prelude-custom.el
+++ b/core/prelude-custom.el
@@ -64,6 +64,11 @@ Will only occur if `prelude-whitespace' is also enabled."
   :type 'boolean
   :group 'prelude)
 
+(defcustom prelude-smartparens-strict t
+  "Non-nil values enable smartparens-strict for lisps."
+  :type 'boolean
+  :group 'prelude)
+
 (defcustom prelude-user-init-file (expand-file-name "personal/"
                                                     user-emacs-directory)
   "Path to your personal customization file.

--- a/modules/prelude-common-lisp.el
+++ b/modules/prelude-common-lisp.el
@@ -75,7 +75,8 @@
   ;; rainbow-delimeters messes up colors in slime-repl, and doesn't seem to work
   ;; anyway, so we won't use prelude-lisp-coding-defaults.
   (add-hook 'slime-repl-mode-hook (lambda ()
-                                    (smartparens-strict-mode +1)
+                                    (when prelude-smartparens-strict
+                                      (smartparens-strict-mode +1))
                                     (whitespace-mode -1)))
 
   (define-key slime-mode-map (kbd "C-c C-s") 'slime-selector))

--- a/modules/prelude-lisp.el
+++ b/modules/prelude-lisp.el
@@ -46,14 +46,16 @@
 
 ;; a great lisp coding hook
 (defun prelude-lisp-coding-defaults ()
-  (smartparens-strict-mode +1)
+  (when prelude-smartparens-strict
+    (smartparens-strict-mode +1))
   (rainbow-delimiters-mode +1))
 
 (setq prelude-lisp-coding-hook 'prelude-lisp-coding-defaults)
 
 ;; interactive modes don't need whitespace checks
 (defun prelude-interactive-lisp-coding-defaults ()
-  (smartparens-strict-mode +1)
+  (when prelude-smartparens-strict
+    (smartparens-strict-mode +1))
   (rainbow-delimiters-mode +1)
   (whitespace-mode -1))
 


### PR DESCRIPTION
Defaults to `t`, which preserves original behavior.

Setting to nil prevents smartparens-strict being enabled for
prelude-lisp (and modules that require it, like prelude-clojure).

I for one find strict mode irritating generally and disabled it manually per buffer for far, far, too long. On a sidenote, it doesn't play along very well with parinfer, which I like.

I could have settled for some (personal) hook that disables it again, but I figured it might as well not be enabled in the first place, hence this PR.

`checkdoc` complains about _All variables and subroutines might as well have a documentation string_ on the `(when)` forms. I don't understand what it means since the `(when)` forms are (afaik?) neither variables nor subroutines. I noticed this same warning was also being given in some other prelude files (for example, in `prelude-programming.el`), so I don't believe this to be an issue.
