### PR TITLE
Fix C-c b keybinding (org-switchb)

### DIFF
--- a/modules/prelude-org.el
+++ b/modules/prelude-org.el
@@ -35,7 +35,7 @@
 (add-to-list 'auto-mode-alist '("\\.org\\’" . org-mode))
 (global-set-key "\C-cl" 'org-store-link)
 (global-set-key "\C-ca" 'org-agenda)
-(global-set-key "\C-cb" 'org-iswitchb)
+(global-set-key "\C-cb" 'org-switchb)
 (setq org-log-done t)
 
 (defun prelude-org-mode-defaults ()


### PR DESCRIPTION
`C-c b` in prelude currently causes this error:

```
apply: Wrong type argument: commandp, org-iswitchb
```

Fixes #1258.