### PR TITLE
Replace cl to cl-lib

### DIFF
--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -32,7 +32,7 @@
 ;; Boston, MA 02110-1301, USA.
 
 ;;; Code:
-(require 'cl)
+(require 'cl-lib)
 (require 'package)
 
 ;; accessing a package repo over https on Windows is a no go, so we
@@ -90,7 +90,7 @@
 
 (defun prelude-packages-installed-p ()
   "Check if all packages in `prelude-packages' are installed."
-  (every #'package-installed-p prelude-packages))
+  (cl-every #'package-installed-p prelude-packages))
 
 (defun prelude-require-package (package)
   "Install PACKAGE unless already installed."
@@ -127,7 +127,7 @@ are installed and are not in `prelude-packages'.  Useful for
 removing unwanted packages."
   (interactive)
   (package-show-package-list
-   (set-difference package-activated-list prelude-packages)))
+   (cl-set-difference package-activated-list prelude-packages)))
 
 (defmacro prelude-auto-install (extension package mode)
   "When file with EXTENSION is opened triggers auto-install of PACKAGE.

--- a/modules/prelude-latex.el
+++ b/modules/prelude-latex.el
@@ -35,7 +35,7 @@
 (prelude-require-packages '(auctex cdlatex))
 (require 'smartparens-latex)
 ;; for case
-(require 'cl)
+(require 'cl-lib)
 
 (with-eval-after-load "company"
   (prelude-require-packages '(company-auctex))
@@ -78,7 +78,7 @@
   (turn-on-auto-fill)
   (abbrev-mode +1)
   (smartparens-mode +1)
-  (case prelude-latex-fast-math-entry
+  (cl-case prelude-latex-fast-math-entry
     (LaTeX-math-mode (LaTeX-math-mode 1))
     (cdlatex (turn-on-cdlatex))))
 


### PR DESCRIPTION
On emacs 27.1 cl is oficially deprecated and receives a message
warning in the startup as:

        Package cl is deprecated

Using cl-lib, which prefix all the Common Lisp functions with `cl-`
solves the problem.