### PR TITLE
Add Rusty Object Notation to the Rust package

### DIFF
--- a/modules/prelude-rust.el
+++ b/modules/prelude-rust.el
@@ -40,7 +40,8 @@
 
 (prelude-require-packages '(rust-mode
                             cargo
-                            flycheck-rust))
+                            flycheck-rust
+                            ron-mode))
 
 (unless (featurep 'prelude-lsp)
   (prelude-require-packages '(racer)))


### PR DESCRIPTION
# Add RON Support to the Prelude Rust package
### What is RON?
RON (Rusty Object Notation) is a relatively new JSON-like format used in the Rust ecosystem. This PR adds support for it to the Rust package.

---
### Why not make RON its own package?
1. It is almost exclusively used in Rust

2. It is not large enough to warrent its own package
---

The source code can be found [here](https://chiselapp.com/user/Hutzdog/repository/ron-mode/home).