### PR TITLE
Replaces errant `prelude-mode-map` with `map`

### DIFF
--- a/core/prelude-mode.el
+++ b/core/prelude-mode.el
@@ -79,7 +79,7 @@
       (define-key map (kbd "s-m f") 'magit-log-buffer-file)
       (define-key map (kbd "s-m b") 'magit-blame)
       (define-key map (kbd "s-o") 'crux-smart-open-line-above)
-      (define-key prelude-mode-map (kbd "s-/") 'hippie-expand))
+      (define-key map (kbd "s-/") 'hippie-expand))
     (easy-menu-define prelude-mode-menu map
       "Prelude's menu."
       '("Prelude"


### PR DESCRIPTION
A `map` variable was mistakenly replaced with `prelude-mode-map`. This change replaces `prelude-mode-map` with the correct `map` variable name.

Fixes https://github.com/bbatsov/prelude/issues/1279

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
