### PR TITLE
Fix #1266

### DIFF
--- a/utils/installer.sh
+++ b/utils/installer.sh
@@ -174,7 +174,8 @@ else
 fi
 
 ### Check emacs version
-if [ $(emacs --version 2>/dev/null | sed -n 's/.*[^0-9.]\([0-9]*\.[0-9.]*\).*/\1/p;q' | sed 's/\..*//g') -lt 24 ]
+emacs_version="$(emacs --version 2>/dev/null | sed -n 's/.*[^0-9.]\([0-9]*\.[0-9.]*\).*/\1/p;q' | sed 's/\..*//g')"
+if [ "${emacs_version:-0}" -lt 24 ]
 then
     printf "$YELLOW WARNING:$RESET Prelude depends on emacs $RED 24$RESET !\n"
 fi


### PR DESCRIPTION
The fix is naive -- it'll work fine (printing a warning) if there is no emacs installed, but if emacs *is* installed and just formats the `--version` line differently than the pipeline is expecting, it'll also print the warning -- which isn't *ideal*, but should work in most cases.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [n/a] You've added tests (if possible) to cover your change(s)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality)

Thanks!
