### PR TITLE
transient/ into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ network-security.data
 prelude-cheatsheet.el
 prelude-cheatsheet.aux
 prelude-cheatsheet.log
+transient/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Removed `beacon-mode`.
 * Add the `ag` package. It provides a nice alternative to `grep` and has nice Projectile integration.
 * Auto-install `adoc-mode` for AsciiDoc files.
+* Added `transient/` to `.gitignore`.
 
 ### Bugs fixed
 


### PR DESCRIPTION
Directory transient gets created, at least on first launch. Accordingly, putting it into .gitignore.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
