### PR TITLE
Use EOS instead of EOL for auto mode regexp

### DIFF
--- a/modules/prelude-xml.el
+++ b/modules/prelude-xml.el
@@ -35,7 +35,7 @@
 (push '("<\\?xml" . nxml-mode) magic-mode-alist)
 
 ;; pom files should be treated as xml files
-(add-to-list 'auto-mode-alist '("\\.pom$" . nxml-mode))
+(add-to-list 'auto-mode-alist '("\\.pom\\'" . nxml-mode))
 
 (setq nxml-child-indent 4)
 (setq nxml-attribute-indent 4)


### PR DESCRIPTION
This prevent matching filename like "xxxx.pom\nxxxx". A corner case which satisfies POSIX filename standard but weird for daily use.