### PR TITLE
Add prelude-python-mode-set-encoding-automatically defcustom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changes
 
+* [#1292](https://github.com/bbatsov/prelude/issues/1292): Add `prelude-python-mode-set-encoding-automatically` defcustom on prelude-python.el module with nil default value.
 * [#1278](https://github.com/bbatsov/prelude/issues/1278): Don't disable `menu-bar-mode` unless `prelude-minimalistic-ui` is enabled.
 * [#1277](https://github.com/bbatsov/prelude/issues/1277): Make it possible to disable the creation of `Super`-based keybindings via `prelude-super-keybindings`.
 * Removed deprecated alias `prelude-ensure-module-deps`.

--- a/doc/modules/python.md
+++ b/doc/modules/python.md
@@ -20,3 +20,16 @@ syntax checkers, [Pylint](http://www.pylint.org/) and
 order to have Flycheck support on the fly syntax checking for
 Python you need to have either of these installed and accessible to
 Emacs. In order to manually choose a checker run `C-c ! s`.
+
+
+## Automatic insertion of # coding: utf-8
+
+Previously `prelude-python` had this feature enabled by default, but
+that is only necessary on Python2, because Python3 already use utf-8
+as default encoding. In 2020, python2 becames deprecated, so that
+functionallity becames a annoying side-effect for some users. If you
+wish to enable this, add this to your config file:
+
+```emacs-lisp
+(setq prelude-python-mode-set-encoding-automatically t)
+```

--- a/modules/prelude-python.el
+++ b/modules/prelude-python.el
@@ -31,6 +31,11 @@
 
 ;;; Code:
 
+(defcustom prelude-python-mode-set-encoding-automatically nil
+  "Non-nil values enable auto insertion of '# coding: utf-8' on python buffers."
+  :type 'boolean
+  :group 'prelude)
+
 (prelude-require-package 'anaconda-mode)
 
 (when (boundp 'company-backends)
@@ -97,7 +102,8 @@
                 #'python-imenu-create-flat-index))
   (add-hook 'post-self-insert-hook
             #'electric-layout-post-self-insert-function nil 'local)
-  (add-hook 'after-save-hook 'prelude-python-mode-set-encoding nil 'local))
+  (when prelude-python-mode-set-encoding-automatically
+    (add-hook 'after-save-hook 'prelude-python-mode-set-encoding nil 'local)))
 
 (setq prelude-python-mode-hook 'prelude-python-mode-defaults)
 


### PR DESCRIPTION
- if it is nil (default) does nothing
- if non-nil insert '# coding: utf-8' on top of python buffers

Closes #1292

-----------------
- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)