### PR TITLE
[Docs] Fix a typo

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -213,7 +213,7 @@ You can always reactivate Helm with `(prelude-global-helm-global-mode-on)`.
 
     In `helm-M-x`, you have to pass prefix argument *AFTER* you run `helm-M-x`,
     because your prefix argument will be displayed in the modeline when in `helm-M-x`
-    buffer. Passing prefix argument **BEFORE** =helm-M-x= **has no effect**.
+    buffer. Passing prefix argument **BEFORE** `helm-M-x` **has no effect**.
 
 
 #### Key-chords


### PR DESCRIPTION
Quick typo fix for =helm-M-x=:
![image](https://user-images.githubusercontent.com/23771/96028748-90680800-0e0e-11eb-898f-ac60d0ec002b.png)
