### PR TITLE
[fix #1248] [installer] provide switch to leave .emacs untouched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Changes
 
+* [#1248](https://github.com/bbatsov/prelude/issues/1248): Add `-m/--no-move-dotemacs` option to the installer to disable the backing of the user's `.emacs`
 * [#1292](https://github.com/bbatsov/prelude/issues/1292): Add `prelude-python-mode-set-encoding-automatically` defcustom inn `prelude-python.el` module with nil default value.
 * [#1278](https://github.com/bbatsov/prelude/issues/1278): Don't disable `menu-bar-mode` unless `prelude-minimalistic-ui` is enabled.
 * [#1277](https://github.com/bbatsov/prelude/issues/1277): Make it possible to disable the creation of `Super`-based keybindings via `prelude-super-keybindings`.

--- a/utils/installer.sh
+++ b/utils/installer.sh
@@ -60,8 +60,10 @@ colors_ () {
 #   Defaults to 'https://github.com/bbatsov/prelude.git'
 # -i/--into
 #   If one exists, install into the existing config
+# -m/--no-move-dotemacs
+#   Leave '$HOME/.emacs' untouched
 # -n/--no-bytecompile
-#   Skip the compilation of the prelude files.
+#   Skip the compilation of the prelude files
 # -h/--help
 #   Print help
 # -v/--verbose
@@ -75,6 +77,7 @@ usage() {
     printf "  \t \t \t \t Defaults to $HOME/.emacs.d\n"
     printf "  -s, --source [url] \t \t Clone Prelude from 'url'.\n"
     printf "  \t \t \t \t Defaults to 'https://github.com/bbatsov/prelude.git'.\n"
+    printf "  -m, --no-move-dotemacs \t \t Leave '$HOME/.emacs' untouched.\n"
     printf "  -n, --no-bytecompile \t \t Skip the bytecompilation step of Prelude.\n"
     printf "  -i, --into \t \t \t Install Prelude into a subdirectory in the existing configuration\n"
     printf "  \t \t \t \t The default behavior is to install Prelude into the existing\n"
@@ -102,6 +105,10 @@ do
             ;;
         -i | --into)
             PRELUDE_INTO='true'
+            shift 1
+            ;;
+        -m | --no-move-dotemacs)
+            PRELUDE_PRESERVE_DOTEMACS='true'
             shift 1
             ;;
         -n | --no-bytecompile)
@@ -135,6 +142,10 @@ then
     printf "INSTALL_DIR = $PRELUDE_INSTALL_DIR\n"
     printf "SOURCE_URL  = $PRELUDE_URL\n"
     printf "$RESET"
+    if [ -n "$PRELUDE_PRESERVE_DOTEMACS" ]
+    then
+        printf "Leaving ~/.emacs untouched.\n"
+    fi
     if [ -n "$PRELUDE_SKIP_BC" ]
     then
         printf "Skipping bytecompilation.\n"
@@ -180,7 +191,7 @@ then
     printf "$YELLOW WARNING:$RESET Prelude requires Emacs $RED 25$RESET or newer!\n"
 fi
 
-if [ -f "$HOME/.emacs" ]
+if [ -f "$HOME/.emacs" ] && [ -z "$PRELUDE_PRESERVE_DOTEMACS" ]
 then
     ## If $HOME/.emacs exists, emacs ignores prelude's init.el, so remove it
     printf " Backing up the existing $HOME/.emacs to $HOME/.emacs.pre-prelude\n"


### PR DESCRIPTION
### Provide an option in the installer to not perform the backup/move action on the user's .emacs

* Add a command-line switch `-m/--no-move-dotemacs` in the `utils/installer.sh` shell script, in the same style as existing switches.
* Add a condition to the `if` block that performs the `.emacs` move-to-backup-location action.
* Update changelog.

_note: none of the existing installer options are documented in the `doc/installation.md` so I didn't change anything there._

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
