### PR TITLE
In org-mode buffers, bind C-a to org-beginning-of-line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 ### Bugs fixed
 
+* [#1302](https://github.com/bbatsov/prelude/issues/1302): C-a should be bound to org-beginning-of-line in org-mode buffers
+
 ## 1.0.0 (2020-09-15)
 
 Initial "stable" release after 9 years of development.

--- a/modules/prelude-org.el
+++ b/modules/prelude-org.el
@@ -47,7 +47,7 @@
     (set-keymap-parent newmap oldmap)
     (define-key newmap (kbd "C-c +") nil)
     (define-key newmap (kbd "C-c -") nil)
-    (define-key newmap (kbd "C-a") nil)
+    (define-key newmap (kbd "C-a") 'org-beginning-of-line)
     (make-local-variable 'minor-mode-overriding-map-alist)
     (push `(prelude-mode . ,newmap) minor-mode-overriding-map-alist))
 )


### PR DESCRIPTION
org-beginning-of-line is the default for C-a keybinding in org-mode.

Fix #1302
