### PR TITLE
Fix "require org" command and org auto-mode-alist

### DIFF
--- a/modules/prelude-org.el
+++ b/modules/prelude-org.el
@@ -30,7 +30,7 @@
 
 ;;; Code:
 
-(require 'org-mode)
+(require 'org)
 
 (add-to-list 'auto-mode-alist '("\\.org\\’" . org-mode))
 

--- a/modules/prelude-org.el
+++ b/modules/prelude-org.el
@@ -32,7 +32,7 @@
 
 (require 'org)
 
-(add-to-list 'auto-mode-alist '("\\.org\\’" . org-mode))
+(add-to-list 'auto-mode-alist '("\\.org\\'" . org-mode))
 
 ;; a few useful global keybindings for org-mode
 (global-set-key "\C-cl" 'org-store-link)


### PR DESCRIPTION
Hi!

Emacs doesn't find org-mode when using `(require org-mode)` when Org-mode is installed with Emacs Package manager. I think it was renamed `org`.

Moreover, auto-mode-alist REGEXP should not end with typesetter's apostrophe (`’`) but with typewriter apostrophe (`'`).