### PR TITLE
Use lsp-workspace-restart instead of deprecated lsp-restart-workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Fallback to `sample/prelude-modules.el` in the absence of a `prelude-modules.el` in one's personal folder.
 * [Ruby] Don't auto-insert coding comments.
 * Hide (via `diminish`) `editorconfig-mode`, `super-save`, `company`, `abbrev` and `ivy` in the modeline.
+* Use `lsp-workspace-restart` function instead of deprecated `lsp-restart-workspace`.
 
 ### Bugs fixed
 

--- a/modules/prelude-lsp.el
+++ b/modules/prelude-lsp.el
@@ -42,7 +42,7 @@
 (define-key lsp-ui-mode-map (kbd "C-c C-l .") 'lsp-ui-peek-find-definitions)
 (define-key lsp-ui-mode-map (kbd "C-c C-l ?") 'lsp-ui-peek-find-references)
 (define-key lsp-ui-mode-map (kbd "C-c C-l r") 'lsp-rename)
-(define-key lsp-ui-mode-map (kbd "C-c C-l x") 'lsp-restart-workspace)
+(define-key lsp-ui-mode-map (kbd "C-c C-l x") 'lsp-workspace-restart)
 (define-key lsp-ui-mode-map (kbd "C-c C-l w") 'lsp-ui-peek-find-workspace-symbol)
 (define-key lsp-ui-mode-map (kbd "C-c C-l i") 'lsp-ui-peek-find-implementation)
 (define-key lsp-ui-mode-map (kbd "C-c C-l d") 'lsp-describe-thing-at-point)


### PR DESCRIPTION
`lsp-restart-workspace` is deprecated and raises a warning in `*Messages*`:

    ‘lsp-restart-workspace’ is an obsolete command (as of lsp-mode 6.1); use ‘lsp-workspace-restart’ instead.

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)