### PR TITLE
Use display-line-numbers for Emacs 26.1 and later (#1317)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-* Enable `nlinum-mode` by default. Can be disabled by setting `prelude-minimalistic-ui` to `t`.
+* Enable `nlinum-mode` or `display-line-numbers-mode` by default. Can be disabled by setting `prelude-minimalistic-ui` to `t`.
 * Enable site-wide installation for Prelude.
 * Auto-installs `julia-mode` if needed.
 * Auto-install `adoc-mode` for AsciiDoc files.

--- a/core/prelude-ui.el
+++ b/core/prelude-ui.el
@@ -62,8 +62,11 @@
 ;; show line numbers at the beginning of each line
 (unless prelude-minimalistic-ui
   ;; there's a built-in linum-mode, but we're using
-  ;; nlinum-mode, as it's supposedly faster
-  (global-nlinum-mode t))
+  ;; display-line-numbers-mode or nlinum-mode,
+  ;; as it's supposedly faster
+  (if (fboundp 'global-display-line-numbers-mode)
+      (global-display-line-numbers-mode)
+    (global-nlinum-mode t)))
 
 ;; enable y/n answers
 (fset 'yes-or-no-p 'y-or-n-p)


### PR DESCRIPTION
PR for #1317 -- use display-line-numbers mode, which is implemented at the C level for speed benefits, if available.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
