### PR TITLE
Fix diminishing company-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Bugs fixed
 
+* Fix `company` still being visible in the mode line.
+
 ## 1.1.0 (2021-02-14)
 
 ### New features

--- a/modules/prelude-company.el
+++ b/modules/prelude-company.el
@@ -44,7 +44,7 @@
 (setq company-tooltip-flip-when-above t)
 
 (global-company-mode 1)
-(diminish 'global-company-mode)
+(diminish 'company-mode)
 
 (provide 'prelude-company)
 ;;; prelude-company.el ends here


### PR DESCRIPTION
The diminish call on global-company-mode has no effect. To hide the
lighter of company-mode, we must call diminish on company-mode, not its
global companion.

Tested on Emacs 27.2, Linux.
Without this patch, "company" is visible in the mode line.
With this patch, "company" is gone from the mode line.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
