### PR TITLE
Set TLS version to avoid the TLS errors on prelude startup

### DIFF
--- a/init.el
+++ b/init.el
@@ -39,6 +39,7 @@
 ;; You may delete these explanatory comments.
                                         ;(package-initialize)
 
+(setq gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3")
 (defvar prelude-user
   (getenv
    (if (equal system-type 'windows-nt) "USERNAME" "USER")))


### PR DESCRIPTION
I kept getting package errors whenever I try to download from an https repo and this was mainly down to tls errors. Setting this init.el fixes that.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
