### PR TITLE
Enable proced on Darwin for Emacs >= 26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Bind all essential `avy` commands to their recommended keybindings.
 * Remove `company-lsp`.
 * Replace `yank-pop` key-binding to `counse-yank-pop` for `ivy-mode`.
+* The keybinding for `proced` is now enabled unconditionally.
 
 ### Bugs fixed
 

--- a/core/prelude-global-keybindings.el
+++ b/core/prelude-global-keybindings.el
@@ -46,8 +46,7 @@
 (global-set-key (kbd "C-^") 'crux-top-join-line)
 
 ;; Start proced in a similar manner to dired
-(unless (eq system-type 'darwin)
-  (global-set-key (kbd "C-x p") 'proced))
+(global-set-key (kbd "C-x p") 'proced)
 
 ;; Start eshell or switch to it if it's active.
 (global-set-key (kbd "C-x m") 'eshell)


### PR DESCRIPTION
Proced works on Darwin since Emacs 26.1.
See Emacs bug #16579.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
