### PR TITLE
Add F# module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add a Racket module.
 * Add a Lua module.
 * Auto-install `racket-mode` if needed.
+* Add a F# module.
 
 ### Changes
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -65,6 +65,7 @@ The following programming languages have enhanced support in Prelude:
 - [Emacs Lisp](modules/emacs_lisp.md)
 - Erlang
 - Elixir
+- [F#](modules/fsharp.md)
 - Go
 - Haskell
 - JavaScript

--- a/doc/modules/fsharp.md
+++ b/doc/modules/fsharp.md
@@ -1,0 +1,11 @@
+# Prelude F#
+
+!!! Note
+
+    This module builds on top of the shared [Programming](programming.md) module.
+
+## F# mode
+
+This module uses
+[`fsharp-mode`](https://github.com/fsharp/emacs-fsharp-mode) and
+`eglot-fsharp` with almost no extra configuration.

--- a/modules/prelude-fsharp.el
+++ b/modules/prelude-fsharp.el
@@ -28,7 +28,6 @@
 ;;; Code:
 
 (require 'prelude-programming)
-
 (prelude-require-packages '(fsharp-mode eglot-fsharp))
 
 (with-eval-after-load 'fsharp-mode

--- a/modules/prelude-fsharp.el
+++ b/modules/prelude-fsharp.el
@@ -1,0 +1,49 @@
+;;; prelude-fsharp.el --- Emacs Prelude: F# programming support.
+;;
+;; Author: Andre Boechat <andre.boechat@tutanota.com>
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Basic setup for F# programming based on fsharp-mode and Eglot.
+
+;;; License:
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Code:
+
+(require 'prelude-programming)
+
+(prelude-require-packages '(fsharp-mode eglot-fsharp))
+
+(with-eval-after-load 'fsharp-mode
+  (defun prelude-fsharp-mode-defaults ()
+    ;; A reasonable default path to the F# compiler and interpreter on
+    ;; Unix-like systems.
+    ;; https://github.com/fsharp/emacs-fsharp-mode#compiler-and-repl-paths
+    (setq inferior-fsharp-program "dotnet fsi --readline-")
+    (require 'eglot-sharp))
+
+  (setq prelude-fsharp-mode-hook 'prelude-fsharp-mode-defaults)
+
+  (add-hook 'fsharp-mode-hook (lambda ()
+                                (run-hooks 'prelude-sharp-mode-hook))))
+
+(provide 'prelude-fsharp)
+
+;;; prelude-fsharp.el ends here

--- a/sample/prelude-modules.el
+++ b/sample/prelude-modules.el
@@ -73,6 +73,7 @@
 (require 'prelude-emacs-lisp)
 ;; (require 'prelude-erlang)
 ;; (require 'prelude-elixir)
+;; (require 'prelude-fsharp)
 ;; (require 'prelude-go)
 ;; (require 'prelude-haskell)
 (require 'prelude-js)


### PR DESCRIPTION
This PR adds support for F# programming using [`fsharp-mode`](https://github.com/fsharp/emacs-fsharp-mode) and `eglot-fsharp` with almost no extra configuration.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
