### PR TITLE
Fixes manual installation docs

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -136,7 +136,7 @@ In case of an automated installation, you'll find this file in the `personal` di
 
 If you are doing a manual install then you first
 need to copy the `prelude-modules.el` available in the sample
-directory to the root of `path/to/prelude/installation` and then
+directory to the `path/to/prelude/installation/personal` directory and then
 adjust that one.
 
 After you've uncommented a module you should either restart Emacs or evaluate the module


### PR DESCRIPTION
The prelude-modules.el file must be copied from sample/ to personal/ and modifed there (not in the prelude root dir).

The problem was mentioned also here, but the reason of the problem was not discovered: https://github.com/bbatsov/prelude/issues/507