### PR TITLE
Fix "Symbol's value as variable is void: kill-region" errors in Emacs 29.0.50

### DIFF
--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -166,6 +166,7 @@
 ;; note - this should be after volatile-highlights is required
 ;; add the ability to cut the current line, without marking it
 (require 'rect)
+(require 'crux)
 (crux-with-region-or-line kill-region)
 
 ;; tramp, for sudo access


### PR DESCRIPTION
This simple change fixes the issues mentioned in #1351. 

The fix is suggested by @billsacks. And I have verified that the proposed change fixes Emacs-29 issues in my machine.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
