### PR TITLE
Document a workaround for fixing C-a in term-mode

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -76,6 +76,25 @@ you don't like that simply add this to your personal config:
                 'move-beginning-of-line)
 ```
 
+If you're using term-mode or ansi-term-mode, the above will not
+restore the default behaviour of sending the C-a key sequence directly
+to the terminal. As a workaround, you can remove the C-a binding from
+prelude-mode specifically for these as described
+[here](https://emacsredux.com/blog/2013/09/25/removing-key-bindings-from-minor-mode-keymaps/)
+by adding something like the following to your personal config:
+
+```emacs-lisp
+(defun my-term-mode-hook ()
+  (let ((oldmap (cdr (assoc 'prelude-mode minor-mode-map-alist)))
+        (newmap (make-sparse-keymap)))
+    (set-keymap-parent newmap oldmap)
+    (define-key newmap (kbd "C-a") nil)
+    (make-local-variable 'minor-mode-overriding-map-alist)
+    (push `(prelude-mode . ,newmap) minor-mode-overriding-map-alist)))
+
+(add-hook 'term-mode-hook 'my-term-mode-hook)
+```
+
 ## Poor ido matching performance on large datasets
 
 Prelude's `ido` module swaps the default `ido` flex matching with the


### PR DESCRIPTION
Even with some non-trivial Emacs background, it took me several hours to figure out how to fix `C-a` in term-mode when using Prelude - which it sort of even encourages to be used, given the `C-c t` binding and its presence in the menu.

There's a couple of threads and issues I found on this, but nothing I saw there actually worked as desired:

https://www.reddit.com/r/emacs/comments/aiivkl/ca_not_working_in_ansiterm/
https://github.com/bbatsov/prelude/issues/1186

Finally, I found this post that had a solution that actually worked: https://emacsredux.com/blog/2013/09/25/removing-key-bindings-from-minor-mode-keymaps/

Probably worth fixing in some way or another in the code, but I think just documenting it in the troubleshooting section should already help most users who run into this. I opted for putting it in the section that already talks about `C-a` now, but a case could be made to give this problem its own section, since I suppose major modes other than term-mode can have similar problems.