### PR TITLE
Disable super-save on go-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Remove `company-lsp`.
 * Replace `yank-pop` key-binding to `counse-yank-pop` for `ivy-mode`.
 * The keybinding for `proced` is now enabled unconditionally.
+* Replace prelude-go backend with `lsp` instead of unmaintained tools
 
 ### Bugs fixed
 

--- a/modules/prelude-go.el
+++ b/modules/prelude-go.el
@@ -45,6 +45,12 @@
 
 (define-key 'help-command (kbd "G") 'godoc)
 
+;; Fix: super-save will cause go files to be saved when lsp-mode does
+;; certain things, triggering lsp-format-buffer. This causes, inter alia,
+;; commas to disappear when typing go function invocations
+(add-to-list 'super-save-predicates
+             (lambda () (not (eq major-mode 'go-mode))))
+
 (with-eval-after-load 'go-mode
   (defun prelude-go-mode-defaults ()
     ;; Add to default go-mode key bindings


### PR DESCRIPTION
Fixes https://github.com/bbatsov/prelude/issues/1372

I don't think `super-save` can work with some LSP features. Basically when displaying documentation for the current function call, `lsp-mode` has to call `switch-to-buffer` and/or `other-window` so I can't just selectively disable those.

The issue that I filed and referenced above explains why this is really irritating.

I also updated the changelog which I forgot to do in my last PR.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
