### PR TITLE
Ignore eln-cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ var/
 .cache/
 .lsp-session*
 gotools/
+eln-cache/


### PR DESCRIPTION
Ever since switching to Emacs 28, which appears to automatically perform native compilation now, I've had that untracked `eln-cache` directory in my working directory. Seems like something that should be ignored, although I'm not 100% sure if it shows up for all Emacs 28 users.

-----------------

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)
