### PR TITLE
Add magit-section to pinned packages

### DIFF
--- a/sample/prelude-pinned-packages.el
+++ b/sample/prelude-pinned-packages.el
@@ -83,6 +83,7 @@
         (macrostep . "melpa-stable")
         (magit . "melpa-stable")
         (magit-popup . "melpa-stable")
+        (magit-section . "melpa-stable")
         (makey . "melpa-stable")
         (markdown-mode . "melpa-stable")
         (marshal . "melpa-stable")


### PR DESCRIPTION
This addresses the

    which-func-ff-hook error: (void-function magit-section--backward-find)

seen when `magit-status` is run in a buffer with imenu support on a fresh Prelude checkout using the sample `prelude-pinned-packages.el`.

In magit 3.3.0, magit-section was spun off into its own package. Later, magit/magit@4727dcb removed `magit-section--backward-find` from `magit-section.el`. Currently, this change is only in non-stable Melpa.  Therefore, unless magit and magit-section are in the same pinned or unpinned state the above error will occur.

-----------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)
