### PR TITLE
Enable cleaner org-habits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### New features
 
+* Enable org-habits
+* Neatly track TODO state changes in a drawer (LOGBOOK) thereby
+  improving readability
 * Add a module to enable Literate Programming
 * Add a Racket module.
 * Add a Lua module.

--- a/docs/modules/orgmode.md
+++ b/docs/modules/orgmode.md
@@ -1,0 +1,17 @@
+# Prelude OrgMode
+
+!!! Note
+    This module builds on the Emacs OrgMode Functionality
+
+## OrgMode
+The module establishes some sensible defaults for `orgmode`
+
+It establishes a few extra keybidings:
+
+* `C-c l` (`org-store-link`)
+* `C-c a` (`org-agenda`)
+* `C-c b` (`org-switchb`)
+
+## org-habits
+It enables [org-habits](https://orgmode.org/manual/Tracking-your-habits.html "org-habits") and [tracks TODO state changes](https://orgmode.org/manual/Tracking-TODO-state-changes.html "todo-state-changes") into a
+[drawer](https://orgmode.org/manual/Drawers.html "org-drawers").

--- a/modules/prelude-org.el
+++ b/modules/prelude-org.el
@@ -31,6 +31,7 @@
 ;;; Code:
 
 (require 'org)
+(require 'org-habit)
 
 (add-to-list 'auto-mode-alist '("\\.org\\'" . org-mode))
 
@@ -40,6 +41,7 @@
 (global-set-key "\C-cb" 'org-switchb)
 
 (setq org-log-done t)
+(setq org-log-into-drawer t)
 
 (defun prelude-org-mode-defaults ()
   (let ((oldmap (cdr (assoc 'prelude-mode minor-mode-map-alist)))


### PR DESCRIPTION
It is a small change in code but a big change in your interaction with your habits (periodic TODO lists)

- Neatly log your TODO state changes into a drawer (default LOGBOOK)
- Enable org-habits to show a consistency graph of your habits

Reference:
- https://orgmode.org/manual/Tracking-TODO-state-changes.html
- https://orgmode.org/manual/Tracking-your-habits.html

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
