### PR TITLE
Search sample/prelude-modules.el in prelude-dir during init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#1335](https://github.com/bbatsov/prelude/issues/1335): Workaround
   for `which-key` bug causing display issues in clients to `emacs --daemon`.
 * Fix **Edit on GitHub** link in ReadTheDocs site.
+* Fix fall back to sample `prelude-modules.el` not working if user has installed to non-default location.
 
 ## 1.1.0 (2021-02-14)
 

--- a/init.el
+++ b/init.el
@@ -138,7 +138,7 @@ by Prelude.")
   (message "[Prelude] Missing personal modules file %s" prelude-modules-file)
   (message "[Prelude] Falling back to the bundled example file sample/prelude-modules.el")
   (message "[Prelude] You should copy this file to your personal configuration folder and tweak it to your liking")
-  (load (expand-file-name "sample/prelude-modules.el" user-emacs-directory)))
+  (load (expand-file-name "sample/prelude-modules.el" prelude-dir)))
 
 ;; config changes made through the customize UI will be stored here
 (setq custom-file (expand-file-name "custom.el" prelude-personal-dir))


### PR DESCRIPTION
If the user installed prelude to different directory via the `PRELUDE_INSTALL_DIR` variable then the sample file won't be found in the `user-emacs-directory`.

I'm currently in the process of updating the docs for the Exercism [Emacs Lisp track](https://exercism.org/tracks/emacs-lisp) and installed prelude as it is [recommended](https://github.com/exercism/emacs-lisp/blob/main/docs/LEARNING.md) on there and ran into this issue.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
