### PR TITLE
Fix copypasta typo in ruby.md

### DIFF
--- a/docs/modules/ruby.md
+++ b/docs/modules/ruby.md
@@ -8,7 +8,7 @@
 
 Emacs comes with Ruby programming support through the built-in
 `ruby-mode`. Whenever you are editing Ruby code run `C-h m` to
-look at the Python mode key bindings. Alternatively look at the
+look at the Ruby mode key bindings. Alternatively look at the
 menu bar entries under Ruby. To toggle the menu bar press `F12`.
 
 Prelude enables `CamelCase` aware editing in Ruby code (via `subword-mode`).


### PR DESCRIPTION
Fixes a tiny typo in the ruby module doc. (I don't think this merits a changelog entry, but happy to amend if you feel otherwise.)

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
