### PR TITLE
updated prelude rust module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Replace `yank-pop` key-binding to `counse-yank-pop` for `ivy-mode`.
 * The keybinding for `proced` is now enabled unconditionally.
 * Replace prelude-go backend with `lsp` instead of unmaintained tools
+* Use `rust-analyzer` as language server for prelude-rust and provide nicer syntax highlighting with `tree-sitter`
 
 ### Bugs fixed
 

--- a/docs/modules/rust.md
+++ b/docs/modules/rust.md
@@ -12,8 +12,7 @@ following packages in your system:
 * `rustc` (Rust compiler)
 * `cargo` (Rust package manager)
 * `rustfmt` (Rust tool for formatting code)
-* `racer` (Rust completion tool, not necessary if `prelude-lsp` is enabled)
-* `rls` (Rust Language Server, if the `prelude-lsp` feature is enabled)
+* `rust-analyzer` (Rust Language Server, required for `prelude-lsp` feature)
 
 ## Rust Mode
 

--- a/docs/modules/rust.md
+++ b/docs/modules/rust.md
@@ -20,6 +20,11 @@ Emacs comes with Rust programming support through the built-in
 `rust-mode`. Whenever you are editing Rust code run <kbd>C-h m</kbd> to
 look at the Rust mode key bindings.
 
+## Syntax highlighting
+
+[tree-sitter-mode](https://emacs-tree-sitter.github.io/) is used for nicer
+syntax highlighting.
+
 ## Syntax checking
 
 Prelude ships with [Flycheck](https://github.com/flycheck/flycheck),


### PR DESCRIPTION
The current `prelude-rust` module used the deprecated `rls` lsp server.

With this PR, `rls` is replaced by the modern `rust-analyzer` lsp-server.
Additionally, `tree-sitter` was added for a nicer syntax highlighting for Rust code.

closes #1374 

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
