### PR TITLE
Remove helm-config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   for `which-key` bug causing display issues in clients to `emacs --daemon`.
 * Fix **Edit on GitHub** link in ReadTheDocs site.
 * Fix fall back to sample `prelude-modules.el` not working if user has installed to non-default location.
+* Stop requiring `helm-config` since upstream has removed the module.
 
 ## 1.1.0 (2021-02-14)
 

--- a/modules/prelude-helm.el
+++ b/modules/prelude-helm.el
@@ -33,7 +33,6 @@
 
 (prelude-require-packages '(helm helm-projectile))
 
-(require 'helm-config)
 (require 'helm-projectile)
 
 (when (executable-find "curl")


### PR DESCRIPTION
In https://github.com/emacs-helm/helm/commit/e81fbbc687705595ab65ae5cd3bdf93c17a90743 the file was removed entirely so the require fails. Since `helm-config` has been unneeded since helm v3.7.0 (~ 2020-08), remove the require.


-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- ~[ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)~
- ~[ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)~
