### PR TITLE
Custom personal dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add a Lua module.
 * Auto-install `racket-mode` if needed.
 * Add a F# module.
+* Custom personal dir
 
 ### Changes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,9 @@ lexicographical order.  The overall loading precedence is:
 3.  `personal/prelude-modules.el` (or deprecated `prelude-modules.el`)
 4.  `personal/*`
 
+By setting the environment variable `PRELUDE_PERSONAL_DIR` the
+personal directory can be placed outside the main prelude directory.
+
 ### Personalization Example
 
 Suppose you want to configure `go-mode` to autoformat on each save.  You

--- a/init.el
+++ b/init.el
@@ -58,7 +58,11 @@
   "The home of Prelude's core functionality.")
 (defvar prelude-modules-dir (expand-file-name  "modules" prelude-dir)
   "This directory houses all of the built-in Prelude modules.")
-(defvar prelude-personal-dir (expand-file-name "personal" prelude-dir)
+(defvar prelude-personal-dir (if-let* ((personal-dir (getenv "PRELUDE_PERSONAL_DIR"))
+                                       (personal-dir-exp (expand-file-name personal-dir))
+                                       (is-dir (file-directory-p personal-dir-exp)))
+                                 personal-dir-exp
+                               (expand-file-name "personal" prelude-dir))
   "This directory is for your personal configuration.
 
 Users of Emacs Prelude are encouraged to keep their personal configuration


### PR DESCRIPTION
By setting PRELUDE_PERSONAL_DIR personal prelude configuration can be kept outside the main prelude directory.
