### PR TITLE
Remove consult-apropos

### DIFF
--- a/modules/prelude-vertico.el
+++ b/modules/prelude-vertico.el
@@ -103,7 +103,6 @@
          ("C-M-#" . consult-register)
          ;; Other custom bindings
          ("M-y" . consult-yank-pop)                ;; orig. yank-pop
-         ("<help> a" . consult-apropos)            ;; orig. apropos-command
          ;; M-g bindings (goto-map)
          ("M-g e" . consult-compile-error)
          ("M-g f" . consult-flycheck)


### PR DESCRIPTION
consult.el [Version
0.32](https://github.com/minad/consult/blob/main/CHANGELOG.org#version-032-2023-02-06) removed the `consult-apropos` function. Remove the keybinding from prelude configuration so that a working apropos is available.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
