### PR TITLE
Use js2-mode for additional Node.js extensions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * The keybinding for `proced` is now enabled unconditionally.
 * Replace prelude-go backend with `lsp` instead of unmaintained tools.
 * Use `rust-analyzer` as language server for prelude-rust and provide nicer syntax highlighting with `tree-sitter`.
+* Use `js2-mode` for Node.js specific `.cjs` and `.mjs` extensions.
 
 ### Bugs fixed
 

--- a/modules/prelude-js.el
+++ b/modules/prelude-js.el
@@ -35,9 +35,10 @@
 
 (require 'js2-mode)
 
-(add-to-list 'auto-mode-alist '("\\.js\\'"    . js2-mode))
-(add-to-list 'auto-mode-alist '("\\.pac\\'"   . js2-mode))
-(add-to-list 'interpreter-mode-alist '("node" . js2-mode))
+(add-to-list 'auto-mode-alist '("\\.js\\'"     . js2-mode))
+(add-to-list 'auto-mode-alist '("\\.[cm]js\\'" . js2-mode))
+(add-to-list 'auto-mode-alist '("\\.pac\\'"    . js2-mode))
+(add-to-list 'interpreter-mode-alist '("node"  . js2-mode))
 
 (with-eval-after-load 'js2-mode
   (defun prelude-js-mode-defaults ()


### PR DESCRIPTION
Node.js can file extensions to force ECMAScript (.mjs) versus CommonJS (.cjs) module systems. They're both JavaScript files so use js2-mode when editing them.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)
