### PR TITLE
Allow the option of not overriding package-user-dir

### DIFF
--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -50,7 +50,8 @@
       (load prelude-pinned-packages-file)))
 
 ;; set package-user-dir to be relative to Prelude install path
-(setq package-user-dir (expand-file-name "elpa" prelude-dir))
+(when prelude-override-package-user-dir
+  (setq package-user-dir (expand-file-name "elpa" prelude-dir)))
 
 (unless package--initialized
     (package-initialize))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -199,3 +199,12 @@ behaviour, add the following to your config.
 Some of these settings (those that don't need to be pre-loaded) can also be set
 on a per-file or directory basis by using a file local variable or a
 `.dir-locals.el` file.
+
+### package-user-dir
+
+By default, prelude sets the directory where downloaded modules are installed to `<prelude-dir>/elpa`. If you want
+to disable this behaviour, set the following variable to nil before loading prelude.
+
+```emacs-lisp
+(setq prelude-override-package-user-dir nil)
+```

--- a/init.el
+++ b/init.el
@@ -72,6 +72,9 @@ by Prelude.")
   "This folder stores all the automatically generated save/history-files.")
 (defvar prelude-modules-file (expand-file-name "prelude-modules.el" prelude-personal-dir)
   "This file contains a list of modules that will be loaded by Prelude.")
+(defvar prelude-override-package-user-dir t
+  "By default prelude installs downloaded packages in <prelude-dir>/elpa.
+   Set to nil to override this behaviour")
 
 (unless (file-exists-p prelude-savefile-dir)
   (make-directory prelude-savefile-dir))


### PR DESCRIPTION
Currently prelude overrides user-package-dir to be <prelude-dir>/elpa

This patch does not change that behaviour, but gives the user to disable it.

Adds a variable prelude-override-package-user-dir that by default is t.

The path is only set when prelude-override-package-user-dir is true

Addresses #1406

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ X] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
