### PR TITLE
Improvment prelude for emacs 26.1

### DIFF
--- a/core/prelude-linux.el
+++ b/core/prelude-linux.el
@@ -35,6 +35,8 @@
 (prelude-require-packages '(exec-path-from-shell))
 
 (require 'exec-path-from-shell)
+;; for situation when not working gnome-keyring for magit
+;; (exec-path-from-shell-copy-env "SSH_AUTH_SOCK")
 (exec-path-from-shell-initialize)
 
 (provide 'prelude-linux)

--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -38,11 +38,12 @@
 
 ;; accessing a package repo over https on Windows is a no go, so we
 ;; fallback to http there
-(if (eq system-type 'windows-nt)
+(if (and (>= emacs-major-version 27) (>= emacs-minor-version 1))
+  (if (eq system-type 'windows-nt)
+      (add-to-list 'package-archives
+                   '("melpa" . "http://melpa.org/packages/") t)
     (add-to-list 'package-archives
-                 '("melpa" . "http://melpa.org/packages/") t)
-  (add-to-list 'package-archives
-               '("melpa" . "https://melpa.org/packages/") t))
+                 '("melpa" . "https://melpa.org/packages/") t)))
 
 ;; load the pinned packages
 (let ((prelude-pinned-packages-file (expand-file-name "prelude-pinned-packages.el" prelude-dir)))
@@ -55,6 +56,8 @@
 
 ;; install & enable use-package
 (unless (package-installed-p 'use-package)
+  ;; emacs 26.1 can't install package use-package if not do refresh
+  (package-refresh-contents)
   (package-install 'use-package))
 
 (require 'use-package)

--- a/init.el
+++ b/init.el
@@ -47,6 +47,9 @@
 
 (when (version< emacs-version "25.1")
   (error "[Prelude] Prelude requires GNU Emacs 25.1 or newer, but you're running %s" emacs-version))
+(when (version<= emacs-version "26.2")
+  ;; require Gnutls >= 3.6
+  (setq gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3"))
 
 ;; Always load newest byte code
 (setq load-prefer-newer t)

--- a/sample/prelude-modules.el
+++ b/sample/prelude-modules.el
@@ -42,8 +42,10 @@
 ;;; General productivity tools
 
 ;; (require 'prelude-ido) ;; Supercharges Emacs completion for C-x C-f and more
-;; (require 'prelude-ivy) ;; A mighty modern alternative to ido
-(require 'prelude-vertico) ;; A powerful, yet simple, alternative to ivy
+(if (version< emacs-version "27.1")
+    (require 'prelude-ivy) ;; A mighty modern alternative to ido
+  (require 'prelude-vertico)) ;; A powerful, yet simple, alternative to ivy
+
 ;; (require 'prelude-helm) ;; Interface for narrowing and search
 ;; (require 'prelude-helm-everywhere) ;; Enable Helm everywhere
 (require 'prelude-company)


### PR DESCRIPTION
Hello. I tryed install prelude-mode in emacs 26.1 and it's not working the out of box.
Many packages in MELPA required emcas 27.1.
I read "Pinning packages" from documentation, but i don't understand how correct enabled via variables.

What i do:
1. copy prelude-pinned-packages.el in emacs.d/ (root folder) because prelude-packages.el automatically load this file if have.
2. disabled melpa reposilory because after added pinned packages the stable melpa not have priority over melpa
3. refresh packages before install use-packages, otherwise package not installed
4. changed vertico by default on ivy for emacs < 27.1 because vertico in stable melpa required 27.1
5. (*) added SSH_AUTH_SOCK in exec-path-from-shell for situation if somebody can't use ssh for magit (disabled by default)

As a result the prelude not working in emacs 25.1 the out of box. Many packages minimum requre 27.1 or 26.1.
To maintain backward compatibility, I see quelpa.

If my solution will be right, I updated changelog and documentation

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
