### PR TITLE
Fix: autocomplete hang in rust-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Fix fall back to sample `prelude-modules.el` not working if user has installed to non-default location.
 * Stop requiring `helm-config` since upstream has removed the module.
 * Require `typescript-mode` using `prelude-require-packages` to avoid error upon inclusion in `personal/prelude-modules.el`.
+* Turn off `super-save` in `rust-mode` to prevent severe hangs during autocomplete.
 
 ## 1.1.0 (2021-02-14)
 

--- a/modules/prelude-rust.el
+++ b/modules/prelude-rust.el
@@ -48,6 +48,9 @@
 (require 'tree-sitter)
 (require 'tree-sitter-langs)
 
+(add-to-list 'super-save-predicates
+             (lambda () (not (eq major-mode 'rust-mode))))
+
 (with-eval-after-load 'rust-mode
   (add-hook 'rust-mode-hook 'cargo-minor-mode)
   (add-hook 'flycheck-mode-hook 'flycheck-rust-setup)


### PR DESCRIPTION
Related to #1372, it appears that `super-save` doesn't play nicely with LSP features in `rust-mode` either.

My particular issue occurs when using autocomplete in rust. Typing "B" in the following snippet:

```rust
Example(B)
```

Results in emacs hanging as it saves the buffer while LSP mode is attempting to display autocompletions. This seems to cause an infinite loop.

I narrowed the issue down to `super-save` and confirmed that turning it off resolves the issue.

This PR re-implements the fix from #1373 by turning off `super-save` for `rust-mode`.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
