### PR TITLE
Fix loading of prelude-editor for Emacs 30

### DIFF
--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -381,7 +381,14 @@ indent yanked text (with prefix arg don't indent)."
 
 ;; operate-on-number
 (require 'operate-on-number)
-(require 'smartrep)
+
+;; Until https://github.com/myuhe/smartrep.el/pull/25 is merged, use a fork of smartrep for emacs 30.0
+(if (version< emacs-version "30.0.50")
+  (require 'smartrep)
+  (use-package smartrep 
+    :vc (:url "https://github.com/rgiar/smartrep.el"
+         :branch "master"
+         :rev :newest)))
 
 (smartrep-define-key global-map "C-c ."
   '(("+" . apply-operation-to-number-at-point)

--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -87,7 +87,7 @@
     nlinum
     operate-on-number
     smartparens
-    smartrep
+    ;; smartrep ; temporarily installed manually until https://github.com/myuhe/smartrep.el/pull/25 is merged
     super-save
     undo-tree
     volatile-highlights
@@ -124,6 +124,14 @@ Missing packages are installed automatically."
 
 ;; run package installation
 (prelude-install-packages)
+
+;; Until https://github.com/myuhe/smartrep.el/pull/25 is merged, use a fork of smartrep for emacs 30.0
+(if (version< emacs-version "30.0.50")
+  (add-to-list 'prelude-packages 'smartrep))
+  (use-package smartrep 
+    :vc (:url "https://github.com/rgiar/smartrep.el"
+         :branch "master"
+         :rev :newest))
 
 (defun prelude-list-foreign-packages ()
   "Browse third-party packages not bundled with Prelude.


### PR DESCRIPTION
Fixes bbatsov/prelude#1416 by adding a workaround for dgutov/diff-hl#217
