### PR TITLE
Update dap-dart-setup to lsp-dart-dap-setup in prelude-dart.el

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Stop requiring `helm-config` since upstream has removed the module.
 * Require `typescript-mode` using `prelude-require-packages` to avoid error upon inclusion in `personal/prelude-modules.el`.
 * Turn off `super-save` in `rust-mode` to prevent severe hangs during autocomplete.
+* Update `prelude-dart.el` to use `lsp-dart-dap-setup` instead of deprecated `dap-dart-setup` function.
 
 ## 1.1.0 (2021-02-14)
 

--- a/modules/prelude-dart.el
+++ b/modules/prelude-dart.el
@@ -44,7 +44,7 @@
     ;; Add to default dart-mode key bindings
     (lsp-dart-define-key "s o" #'lsp-dart-show-outline)
     (lsp-dart-define-key "s f" #'lsp-dart-show-flutter-outline)
-    (dap-dart-setup))
+    (lsp-dart-dap-setup))
 
   (setq prelude-dart-mode-hook 'prelude-dart-mode-defaults)
 


### PR DESCRIPTION
This commit updates the deprecated function in prelude-dart.el to the latest one.

This PR aims to keep the Dart development environment in Emacs up-to-date.

🔍 Additional information:
- This change was introduced in lsp-dart v1.19.0. (Reference: https://github.com/emacs-lsp/lsp-dart/blob/9ffbafb7dcea3ef3d9e29bafb51d5167f0585d2c/CHANGELOG.md?plain=1#L79)
- The `dap-dart-setup` function is now deprecated and replaced by `lsp-dart-dap-setup`.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!