### PR TITLE
Make `hippie-expand` configuration optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#1421](https://github.com/bbatsov/prelude/issues/1421): Make it possible to configure the TypeScript format action using `prelude-ts-format-action`.
 - [#1354](https://github.com/bbatsov/prelude/issues/1354): Remove default `C--` and `C-+` keybindings to increase/decrease the font size.
 - Add `prelude-projectile` user option, allowing Projectile integration to be disabled.
+- Add `prelude-hippie-expand` user option, allowing hippie-expand support to be disabled.
 
 ### Changes
 

--- a/core/prelude-custom.el
+++ b/core/prelude-custom.el
@@ -127,6 +127,11 @@ Only modes that don't derive from `prog-mode' should be listed here."
   :type 'boolean
   :group 'prelude)
 
+(defcustom prelude-hippie-expand t
+  "Non-nil values enable Prelude's hippie-expand support."
+  :type 'boolean
+  :group 'prelude)
+
 (provide 'prelude-custom)
 
 ;;; prelude-custom.el ends here

--- a/core/prelude-editor.el
+++ b/core/prelude-editor.el
@@ -59,16 +59,17 @@
 (global-auto-revert-mode t)
 
 ;; hippie expand is dabbrev expand on steroids
-(setq hippie-expand-try-functions-list '(try-expand-dabbrev
-                                         try-expand-dabbrev-all-buffers
-                                         try-expand-dabbrev-from-kill
-                                         try-complete-file-name-partially
-                                         try-complete-file-name
-                                         try-expand-all-abbrevs
-                                         try-expand-list
-                                         try-expand-line
-                                         try-complete-lisp-symbol-partially
-                                         try-complete-lisp-symbol))
+(when prelude-hippie-expand
+  (setq hippie-expand-try-functions-list '(try-expand-dabbrev
+                                           try-expand-dabbrev-all-buffers
+                                           try-expand-dabbrev-from-kill
+                                           try-complete-file-name-partially
+                                           try-complete-file-name
+                                           try-expand-all-abbrevs
+                                           try-expand-list
+                                           try-expand-line
+                                           try-complete-lisp-symbol-partially
+                                           try-complete-lisp-symbol)))
 
 ;; smart tab behavior - indent or complete
 (setq tab-always-indent 'complete)

--- a/core/prelude-global-keybindings.el
+++ b/core/prelude-global-keybindings.el
@@ -81,8 +81,9 @@
 ;; Activate occur easily inside isearch
 (define-key isearch-mode-map (kbd "C-o") 'isearch-occur)
 
-;; use hippie-expand instead of dabbrev
-(global-set-key (kbd "M-/") 'hippie-expand)
+(when prelude-hippie-expand
+  ;; use hippie-expand instead of dabbrev
+  (global-set-key (kbd "M-/") 'hippie-expand))
 
 ;; replace buffer-menu with ibuffer
 (global-set-key (kbd "C-x C-b") 'ibuffer)

--- a/core/prelude-mode.el
+++ b/core/prelude-mode.el
@@ -84,7 +84,8 @@
       (define-key map (kbd "s-m l") 'magit-log-buffer-file)
       (define-key map (kbd "s-m b") 'magit-blame)
       ;; misc
-      (define-key map (kbd "s-/") 'hippie-expand))
+      (when prelude-hippie-expand
+        (define-key map (kbd "s-/") 'hippie-expand)))
     (easy-menu-define prelude-mode-menu map
       "Prelude's menu."
       '("Prelude"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -185,6 +185,15 @@ interaction. To disable this, add the following to your config.
 (setq prelude-projectile nil)
 ```
 
+### Disable hippie-expand
+
+By default, Prelude configures `hippie-expand` as a replacement for Emacs' default `dabbrev`. To disable this
+behaviour, add the following to your config.
+
+``` emacs-lisp
+(setq prelude-hippie-expand nil)
+```
+
 ### Configuration per file or directory
 
 Some of these settings (those that don't need to be pre-loaded) can also be set


### PR DESCRIPTION
Add a new `prelude-hippie-expand` user option, so that integration with `hippie-expand` can optionally be disabled.

This is enabled by default, but it can be useful to turn this off -- for example, if one wishes instead to use Emacs' `dabbrev` for dynamic expansion.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [X] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
