### PR TITLE
Support supplying directories of files in the personal/preload directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@
 - Auto-install `racket-mode` if needed.
 - Add a F# module.
 - Auto-install `use-package`.
-- Add `prelude-vertico` module. Vertico a simpler alternative to `ivy-mode` and supersedes Selectrum.
-- [#1421](https://github.com/bbatsov/prelude/issues/1421): Make it possible to configure the TypeScript format action using `prelude-ts-format-action`.
-- [#1354](https://github.com/bbatsov/prelude/issues/1354): Remove default `C--` and `C-+` keybindings to increase/decrease the font size.
+- Add `prelude-vertico` module. Vertico a simpler alternative to `ivy-mode`.
+- Issue 1421: Use `prelude-ts-format-action` for Typescript.
+- Issue 1354: Remove default `C--` and `C-+` keybindings to increase/decrease the font size.
 - Add `prelude-projectile` user option, allowing Projectile integration to be disabled.
 
 ### Changes
@@ -25,7 +25,7 @@
 - Replace `yank-pop` key-binding to `counse-yank-pop` for `ivy-mode`.
 - The keybinding for `proced` is now enabled unconditionally.
 - Replace prelude-go backend with `lsp` instead of unmaintained tools.
-- Use `rust-analyzer` as language server for prelude-rust and provide nicer syntax highlighting with `tree-sitter`.
+- Use `rust-analyzer` as language server for prelude-rust and `tree-sitter`.
 - Use `js2-mode` for Node.js specific `.cjs` and `.mjs` extensions.
 - Add `prelude-undo-tree` custom variable: allows user disable
   undo-tree integration. Enabled by default to maintain backward-compatibility.
@@ -33,10 +33,9 @@
 ### Bugs fixed
 
 - Fix `company` still being visible in the mode line.
-- [#1335](https://github.com/bbatsov/prelude/issues/1335): Workaround
-  for `which-key` bug causing display issues in clients to `emacs --daemon`.
+- Issue 1335: Helps with `which-key` display bug in `emacs --daemon` clients.
 - Fix **Edit on GitHub** link in ReadTheDocs site.
-- Fix fall back to sample `prelude-modules.el` not working if user has installed to non-default location.
+- Fix fallback to sample `prelude-modules.el` for non-default install locations.
 - Stop requiring `helm-config` since upstream has removed the module.
 - Require `typescript-mode` using `prelude-require-packages`.
 - Turn off `super-save` in `rust-mode` to prevent hangs during autocomplete.
@@ -56,7 +55,7 @@
 
 ### Changes
 
-- [#1292](https://github.com/bbatsov/prelude/issues/1292): Add `prelude-python-mode-set-encoding-automatically` defcustom inn `prelude-python.el` module with nil default value.
+- Issue 1292: Add `prelude-python-mode-set-encoding-automatically` defcustom.
 - [#1278](https://github.com/bbatsov/prelude/issues/1278): Don't disable `menu-bar-mode` unless `prelude-minimalistic-ui` is enabled.
 - [#1277](https://github.com/bbatsov/prelude/issues/1277): Make it possible to disable the creation of `Super`-based keybindings via `prelude-super-keybindings`.
 - Removed deprecated alias `prelude-ensure-module-deps`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-- Allow users to include directories custom Emacs Lisp files in `personal/preload` instead of only files.
+- [PR #1432](https://github.com/bbatsov/prelude/pull/1432): Allow users to include directories of custom Emacs Lisp files in `personal/preload` instead of only files.
 - Enable `org-habits`.
 - Neatly track `TODO` state changes in a drawer (LOGBOOK), thereby improving readability.
 - Add a module to enable Literate Programming (`prelude-literal-programming.el`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### New features
 
-- PR 1432: Allow directories of custom Emacs Lisp files in `personal/preload`.
+- [PR 1432](https://github.com/bbatsov/prelude/pull/1432): Allow directories of custom Emacs Lisp files in `personal/preload`.
 - Enable `org-habits`.
 - Neatly track `TODO` state changes in a drawer (LOGBOOK), thereby improving readability.
 - Add a module to enable Literate Programming (`prelude-literal-programming.el`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,8 @@
 ### Changes
 
 - Issue 1292: Add `prelude-python-mode-set-encoding-automatically` defcustom.
-- [#1278](https://github.com/bbatsov/prelude/issues/1278): Don't disable `menu-bar-mode` unless `prelude-minimalistic-ui` is enabled.
-- [#1277](https://github.com/bbatsov/prelude/issues/1277): Make it possible to disable the creation of `Super`-based keybindings via `prelude-super-keybindings`.
+- Issue 1278: Don't disable `menu-bar-mode` unless `prelude-minimalistic-ui` is enabled.
+- Issue 1277: Make it possible to disable the creation of `Super`-based keybindings via `prelude-super-keybindings`.
 - Removed deprecated alias `prelude-ensure-module-deps`.
 - Remove `prelude-fullscreen`, as these days people can use `toggle-frame-fullscreen` instead. (it was introduced in Emacs 24.4)
 - Removed `beacon-mode`.
@@ -72,7 +72,7 @@
 
 ### Bugs fixed
 
-- [#1302](https://github.com/bbatsov/prelude/issues/1302): `C-a` should be bound to `org-beginning-of-line` in org-mode buffers.
+- Issue 1302: `C-a` is bound to `org-beginning-of-line` in org-mode buffers.
 
 ## 1.0.0 (2020-09-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD013 -->
+
 # Change log
 
 ## master (unreleased)
@@ -13,10 +15,11 @@
 - Auto-install `racket-mode` if needed.
 - Add a F# module.
 - Auto-install `use-package`.
-- Add `prelude-vertico` module. Vertico a simpler alternative to `ivy-mode`.
-- Issue 1421: Use `prelude-ts-format-action` for Typescript.
-- Issue 1354: Remove default `C--` and `C-+` keybindings to increase/decrease the font size.
+- Add `prelude-vertico` module. Vertico a simpler alternative to `ivy-mode` and supersedes Selectrum.
+- [#1421](https://github.com/bbatsov/prelude/issues/1421): Make it possible to configure the TypeScript format action using `prelude-ts-format-action`.
+- [#1354](https://github.com/bbatsov/prelude/issues/1354): Remove default `C--` and `C-+` keybindings to increase/decrease the font size.
 - Add `prelude-projectile` user option, allowing Projectile integration to be disabled.
+- Add `prelude-hippie-expand` user option, allowing hippie-expand support to be disabled.
 
 ### Changes
 
@@ -25,39 +28,41 @@
 - Replace `yank-pop` key-binding to `counse-yank-pop` for `ivy-mode`.
 - The keybinding for `proced` is now enabled unconditionally.
 - Replace prelude-go backend with `lsp` instead of unmaintained tools.
-- Use `rust-analyzer` as language server for prelude-rust and `tree-sitter`.
+- Use `rust-analyzer` as language server for prelude-rust and provide nicer syntax highlighting with `tree-sitter`.
 - Use `js2-mode` for Node.js specific `.cjs` and `.mjs` extensions.
 - Add `prelude-undo-tree` custom variable: allows user disable
   undo-tree integration. Enabled by default to maintain backward-compatibility.
 
 ### Bugs fixed
 
+- [PR 1433](https://github.com/bbatsov/prelude/pull/1433): Remove a duplicate `when` call in `modules/prelude-helm-everywhere.el` causing an emacs init error when `prelude-helm-everywhere` is enabled.
 - Fix `company` still being visible in the mode line.
-- Issue 1335: Helps with `which-key` display bug in `emacs --daemon` clients.
+- [#1335](https://github.com/bbatsov/prelude/issues/1335): Workaround
+  for `which-key` bug causing display issues in clients to `emacs --daemon`.
 - Fix **Edit on GitHub** link in ReadTheDocs site.
-- Fix fallback to sample `prelude-modules.el` for non-default install locations.
+- Fix fall back to sample `prelude-modules.el` not working if user has installed to non-default location.
 - Stop requiring `helm-config` since upstream has removed the module.
-- Require `typescript-mode` using `prelude-require-packages`.
-- Turn off `super-save` in `rust-mode` to prevent hangs during autocomplete.
-- Update `prelude-dart.el` to use `lsp-dart-dap-setup`.
+- Require `typescript-mode` using `prelude-require-packages` to avoid error upon inclusion in `personal/prelude-modules.el`.
+- Turn off `super-save` in `rust-mode` to prevent severe hangs during autocomplete.
+- Update `prelude-dart.el` to use `lsp-dart-dap-setup` instead of deprecated `dap-dart-setup` function.
 
 ## 1.1.0 (2021-02-14)
 
 ### New features
 
-- Enable `nlinum-mode` or `display-line-numbers-mode` by default.
+- Enable `nlinum-mode` or `display-line-numbers-mode` by default. Can be disabled by setting `prelude-minimalistic-ui` to `t`.
 - Enable site-wide installation for Prelude.
 - Auto-installs `julia-mode` if needed.
 - Auto-install `adoc-mode` for AsciiDoc files.
-- Add the `ag` package. Its a nice alternative to `grep`.
-- Added config modules for WSL (`prelude-wsl`) and Windows (`prelude-windows`).
+- Add the `ag` package. It provides a nice alternative to `grep` and has nice Projectile integration.
+- Added additional configuration modules for WSL (`prelude-wsl`) and Windows (`prelude-windows`).
 - Add `prelude-selectrum` module. Selectrum a simpler alternative to `ivy-mode`.
 
 ### Changes
 
-- Issue 1292: Add `prelude-python-mode-set-encoding-automatically` defcustom.
-- Issue 1278: Don't disable `menu-bar-mode` unless `prelude-minimalistic-ui` is enabled.
-- Issue 1277: Make it possible to disable the creation of `Super`-based keybindings via `prelude-super-keybindings`.
+- [#1292](https://github.com/bbatsov/prelude/issues/1292): Add `prelude-python-mode-set-encoding-automatically` defcustom inn `prelude-python.el` module with nil default value.
+- [#1278](https://github.com/bbatsov/prelude/issues/1278): Don't disable `menu-bar-mode` unless `prelude-minimalistic-ui` is enabled.
+- [#1277](https://github.com/bbatsov/prelude/issues/1277): Make it possible to disable the creation of `Super`-based keybindings via `prelude-super-keybindings`.
 - Removed deprecated alias `prelude-ensure-module-deps`.
 - Remove `prelude-fullscreen`, as these days people can use `toggle-frame-fullscreen` instead. (it was introduced in Emacs 24.4)
 - Removed `beacon-mode`.
@@ -72,7 +77,7 @@
 
 ### Bugs fixed
 
-- Issue 1302: `C-a` is bound to `org-beginning-of-line` in org-mode buffers.
+- [#1302](https://github.com/bbatsov/prelude/issues/1302): `C-a` should be bound to `org-beginning-of-line` in org-mode buffers.
 
 ## 1.0.0 (2020-09-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-- [PR 1432](https://github.com/bbatsov/prelude/pull/1432): Allow directories of custom Emacs Lisp files in `personal/preload`.
+- PR 1432: Allow directories of custom Emacs Lisp files in `personal/preload`.
 - Enable `org-habits`.
 - Neatly track `TODO` state changes in a drawer (LOGBOOK), thereby improving readability.
 - Add a module to enable Literate Programming (`prelude-literal-programming.el`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- Allow users to include directories custom Emacs Lisp files in `personal/preload` instead of only files.
 - Enable `org-habits`.
 - Neatly track `TODO` state changes in a drawer (LOGBOOK), thereby improving readability.
 - Add a module to enable Literate Programming (`prelude-literal-programming.el`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-- [PR #1432](https://github.com/bbatsov/prelude/pull/1432): Allow users to include directories of custom Emacs Lisp files in `personal/preload` instead of only files.
+- [PR 1432](https://github.com/bbatsov/prelude/pull/1432): Allow directories of custom Emacs Lisp files in `personal/preload`.
 - Enable `org-habits`.
 - Neatly track `TODO` state changes in a drawer (LOGBOOK), thereby improving readability.
 - Add a module to enable Literate Programming (`prelude-literal-programming.el`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
 - [#1421](https://github.com/bbatsov/prelude/issues/1421): Make it possible to configure the TypeScript format action using `prelude-ts-format-action`.
 - [#1354](https://github.com/bbatsov/prelude/issues/1354): Remove default `C--` and `C-+` keybindings to increase/decrease the font size.
 - Add `prelude-projectile` user option, allowing Projectile integration to be disabled.
-- Add `prelude-hippie-expand` user option, allowing hippie-expand support to be disabled.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,20 +38,20 @@
 - Fix **Edit on GitHub** link in ReadTheDocs site.
 - Fix fall back to sample `prelude-modules.el` not working if user has installed to non-default location.
 - Stop requiring `helm-config` since upstream has removed the module.
-- Require `typescript-mode` using `prelude-require-packages` to avoid error upon inclusion in `personal/prelude-modules.el`.
-- Turn off `super-save` in `rust-mode` to prevent severe hangs during autocomplete.
-- Update `prelude-dart.el` to use `lsp-dart-dap-setup` instead of deprecated `dap-dart-setup` function.
+- Require `typescript-mode` using `prelude-require-packages`.
+- Turn off `super-save` in `rust-mode` to prevent hangs during autocomplete.
+- Update `prelude-dart.el` to use `lsp-dart-dap-setup`.
 
 ## 1.1.0 (2021-02-14)
 
 ### New features
 
-- Enable `nlinum-mode` or `display-line-numbers-mode` by default. Can be disabled by setting `prelude-minimalistic-ui` to `t`.
+- Enable `nlinum-mode` or `display-line-numbers-mode` by default.
 - Enable site-wide installation for Prelude.
 - Auto-installs `julia-mode` if needed.
 - Auto-install `adoc-mode` for AsciiDoc files.
-- Add the `ag` package. It provides a nice alternative to `grep` and has nice Projectile integration.
-- Added additional configuration modules for WSL (`prelude-wsl`) and Windows (`prelude-windows`).
+- Add the `ag` package. Its a nice alternative to `grep`.
+- Added config modules for WSL (`prelude-wsl`) and Windows (`prelude-windows`).
 - Add `prelude-selectrum` module. Selectrum a simpler alternative to `ivy-mode`.
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD013 -->
+<!-- markdownlint-disable MD013 MD024 -->
 
 # Change log
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [#1421](https://github.com/bbatsov/prelude/issues/1421): Make it possible to configure the TypeScript format action using `prelude-ts-format-action`.
 - [#1354](https://github.com/bbatsov/prelude/issues/1354): Remove default `C--` and `C-+` keybindings to increase/decrease the font size.
 - Add `prelude-projectile` user option, allowing Projectile integration to be disabled.
+- Add `prelude-hippie-expand` user option, allowing hippie-expand support to be disabled.
 
 ### Changes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD013 MD046 -->
+
 # Configuration
 
 ## User Interface

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,10 +74,10 @@ Finally, if you don't want any theme at all, you can add this to your
 
 ## Personalizing
 
-All files you create under the `personal/` directory are yours for
+All files or directories of files you create under the `personal/` directory are yours for
 personalization.  There is no single special personal config file --
-any files you create in the `personal/` directory will be loaded in
-lexicographical order.  The overall loading precedence is:
+any files or directories of files you create in the `personal/` directory will be loaded in
+lexicographical order (files first and then directories of files).  The overall loading precedence is:
 
 1. `personal/preload/*`
 2. `core/`

--- a/init.el
+++ b/init.el
@@ -102,6 +102,9 @@ by Prelude.")
 (when (file-exists-p prelude-personal-preload-dir)
   (message "[Prelude] Loading personal configuration files in %s..." prelude-personal-preload-dir)
   (mapc 'load (directory-files prelude-personal-preload-dir 't "^[^#\.].*el$")))
+(when (file-directory-p prelude-personal-preload-dir)
+  (message "[Prelude] Loading personal configuration files from directories in %s..." prelude-personal-preload-dir)
+  (mapc 'load (directory-files-recursively prelude-personal-preload-dir "^[^#\.].*el$")))
 
 (message "[Prelude] Loading Prelude's core modules...")
 

--- a/init.el
+++ b/init.el
@@ -99,11 +99,8 @@ by Prelude.")
 (setq large-file-warning-threshold 100000000)
 
 ;; preload the personal settings from `prelude-personal-preload-dir'
-(when (file-exists-p prelude-personal-preload-dir)
-  (message "[Prelude] Loading personal configuration files in %s..." prelude-personal-preload-dir)
-  (mapc 'load (directory-files prelude-personal-preload-dir 't "^[^#\.].*el$")))
 (when (file-directory-p prelude-personal-preload-dir)
-  (message "[Prelude] Loading personal configuration files from directories in %s..." prelude-personal-preload-dir)
+  (message "[Prelude] Loading personal configuration files from files and directories in %s..." prelude-personal-preload-dir)
   (mapc 'load (directory-files-recursively prelude-personal-preload-dir "^[^#\.].*el$")))
 
 (message "[Prelude] Loading Prelude's core modules...")


### PR DESCRIPTION
Currently the `personal/preload` directory accepts `.el` files.  This PR allows you to include directories in the `personal/preload` directory, and all `.el` files recursively found in those directories will be loaded as well.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
