### PR TITLE
Remove duplicate when call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Bugs fixed
 
+- [PR 1433](https://github.com/bbatsov/prelude/pull/1433): Remove a duplicate `when` call in `modules/prelude-helm-everywhere.el` causing an emacs init error when `prelude-helm-everywhere` is enabled.
 - Fix `company` still being visible in the mode line.
 - [#1335](https://github.com/bbatsov/prelude/issues/1335): Workaround
   for `which-key` bug causing display issues in clients to `emacs --daemon`.

--- a/modules/prelude-helm-everywhere.el
+++ b/modules/prelude-helm-everywhere.el
@@ -63,7 +63,7 @@
 (helm-descbinds-mode)
 (helm-mode 1)
 
-(when when prelude-projectile
+(when prelude-projectile
       ;; enable Helm version of Projectile with replacment commands
       (helm-projectile-on))
 


### PR DESCRIPTION
There is a loading error for `prelude-helm-everywhere`.  I am getting an error message `void variable when`.  It let me to this duplicate `when` call.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
