### PR TITLE
Prevent showing errors for command check

### DIFF
--- a/utils/installer.sh
+++ b/utils/installer.sh
@@ -1,3 +1,7 @@
+has() {
+  command -v "$1" >/dev/null 2>&1
+}
+
 install_prelude () {
     printf " Cloning Emacs Prelude's GitHub repository...\n$RESET"
     if [ x$PRELUDE_VERBOSE != x ]
@@ -157,7 +161,7 @@ fi
 
 ### Check dependencies
 printf  "$CYAN Checking to see if git is installed... $RESET"
-if hash git 2>&-
+if has git
 then
     printf "$GREEN found.$RESET\n"
 else
@@ -166,7 +170,7 @@ else
 fi;
 
 printf  "$CYAN Checking to see if aspell is installed... "
-if hash aspell 2>&-
+if has aspell
 then
     printf "$GREEN found.$RESET\n"
 else
@@ -221,7 +225,7 @@ fi
 
 if [ -z "$PRELUDE_SKIP_BC" ];
 then
-    if which emacs > /dev/null 2>&1
+    if has emacs
     then
         printf " Byte-compiling Prelude...\n"
         if [ x$PRELUDE_VERBOSE != x ]


### PR DESCRIPTION
This PR gets rid of errors being shown on install when commands are missing (ie aspell missing):
```
$ curl -L https://github.com/bbatsov/prelude/raw/master/utils/installer.sh | sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  8206  100  8206    0     0  15613      0 --:--:-- --:--:-- --:--:--     0
 Checking to see if git is installed...  found.
 Checking to see if aspell is installed...  not found. Install aspell to benefit from flyspell-mode!
sh: line 169: hash: aspell: not found
 Backing up the existing config to /Users/gertgoet/.emacs.d.pre-prelude.tar.
 Cloning Emacs Prelude's GitHub repository...
Cloning into '/Users/gertgoet/.emacs.d'...
remote: Enumerating objects: 7457, done.
remote: Counting objects: 100% (106/106), done.
remote: Compressing objects: 100% (63/63), done.
remote: Total 7457 (delta 63), reused 45 (delta 43), pack-reused 7351 (from 3)
Receiving objects: 100% (7457/7457), 5.28 MiB | 5.48 MiB/s, done.
Resolving deltas: 100% (4528/4528), done.
 Creating the required directories.
 Byte-compiling Prelude...

  ____           _           _
 |  _ \ _ __ ___| |_   _  __| | ___
 | |_) |  __/ _ \ | | | |/ _  |/ _ \
 |  __/| | |  __/ | |_| | (_| |  __/
 |_|   |_|  \___|_|\__,_|\__,_|\___|

 ... is now installed and ready to do thy bidding, Master gertgoet!
 Don't forget to adjust the modules you want to use in /Users/gertgoet/.emacs.d/personal/prelude-modules.el!
sh: line 169: hash: aspell: not found
 ```

Because of the (repeated) error on the last line, I got the impression it stopped halfway (which was not the case).

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] ~~You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)~~
- [ ] ~~You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)~~
- [X] verified fixed using install from fork

Thanks!
