### PR TITLE
Remove redundant autoload for markdown-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 ### Changes
 
+- Remove redundant addition to `auto-mode-alist` for Markdown
+  (note: this reverts the default to `markdown-mode` instead of `gfm-mode`).
 - Bind all essential `avy` commands to their recommended keybindings.
 - Remove `company-lsp`.
 - Replace `yank-pop` key-binding to `counse-yank-pop` for `ivy-mode`.

--- a/core/prelude-packages.el
+++ b/core/prelude-packages.el
@@ -205,12 +205,6 @@ PACKAGE is installed only if not already present.  The file is opened in MODE."
     ("\\.yaml\\'" yaml-mode yaml-mode)
     ("Dockerfile\\'" dockerfile-mode dockerfile-mode)))
 
-;; markdown-mode doesn't have autoloads for the auto-mode-alist
-;; so we add them manually if it's already installed
-(when (package-installed-p 'markdown-mode)
-  (add-to-list 'auto-mode-alist '("\\.markdown\\'" . gfm-mode))
-  (add-to-list 'auto-mode-alist '("\\.md\\'" . gfm-mode)))
-
 ;; same with adoc-mode
 (when (package-installed-p 'adoc-mode)
   (add-to-list 'auto-mode-alist '("\\.adoc\\'" . adoc-mode))


### PR DESCRIPTION
Remove legacy code adding autoloading for Markdown files, from the days before `markdown-mode` did it itself. This (re)sets the default mode for Markdown to be `markdown-mode`, as is originally in the package itself (unlike `gfm-mode` in Prelude so far).

Closes #1437.
