### PR TITLE
Remove obsolete helm-ag package

### DIFF
--- a/modules/prelude-helm-everywhere.el
+++ b/modules/prelude-helm-everywhere.el
@@ -32,7 +32,6 @@
 
 ;;; Code:
 (require 'prelude-helm)
-(prelude-require-packages '(helm-descbinds helm-ag))
 (require 'helm-eshell)
 
 (global-set-key (kbd "M-x") 'helm-M-x)

--- a/sample/prelude-pinned-packages.el
+++ b/sample/prelude-pinned-packages.el
@@ -66,7 +66,6 @@
         (haml-mode . "melpa-stable")
         (haskell-mode . "melpa-stable")
         (helm . "melpa-stable")
-        (helm-ag . "melpa-stable")
         (helm-core . "melpa-stable")
         (helm-descbinds . "melpa-stable")
         (helm-projectile . "melpa-stable")


### PR DESCRIPTION
Fix for https://github.com/bbatsov/prelude/issues/1441

helm-ag have been removed from melpa and the provided functionality exists in the main helm package.

ref:
https://github.com/melpa/melpa/issues/9496
https://github.com/melpa/melpa/pull/9520

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the [user manual](../blob/master/doc) (if adding/changing user-visible functionality like modules, commands, configuration options, etc)

Thanks!
